### PR TITLE
Merging of fragments into single unfragmented container fixed

### DIFF
--- a/isoparser/pom.xml
+++ b/isoparser/pom.xml
@@ -7,7 +7,7 @@
     <description>A generic parser and writer for all ISO 14496 based files (MP4, Quicktime, DCF, PDCF, ...)
     </description>
     <url>http://code.google.com/p/mp4parser/</url>
-    <version>1.0.3.11</version>
+    <version>1.0.3.11-DASHFIX</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/isoparser/src/main/java/com/googlecode/mp4parser/authoring/Mp4TrackImpl.java
+++ b/isoparser/src/main/java/com/googlecode/mp4parser/authoring/Mp4TrackImpl.java
@@ -75,6 +75,13 @@ public class Mp4TrackImpl extends AbstractTrack {
         }
         subSampleInformationBox = Path.getPath(stbl, "subs");
 
+        // gather all movie fragment boxes from the fragments
+        List<MovieFragmentBox> movieFragmentBoxes = new ArrayList<MovieFragmentBox>();
+        movieFragmentBoxes.addAll(((Box)trackBox.getParent()).getParent().getBoxes(MovieFragmentBox.class));
+        for(IsoFile fragment : fragments) {
+            movieFragmentBoxes.addAll(fragment.getBoxes(MovieFragmentBox.class));
+        }
+
         sampleDescriptionBox = stbl.getSampleDescriptionBox();
         int lastSubsSample = 0;
         final List<MovieExtendsBox> movieExtendsBoxes = trackBox.getParent().getBoxes(MovieExtendsBox.class);
@@ -90,7 +97,7 @@ public class Mp4TrackImpl extends AbstractTrack {
                         List<Long> syncSampleList = new LinkedList<Long>();
 
                         long sampleNumber = 1;
-                        for (MovieFragmentBox movieFragmentBox : ((Box) trackBox.getParent()).getParent().getBoxes(MovieFragmentBox.class)) {
+                        for (MovieFragmentBox movieFragmentBox : movieFragmentBoxes) {
                             List<TrackFragmentBox> trafs = movieFragmentBox.getBoxes(TrackFragmentBox.class);
                             for (TrackFragmentBox traf : trafs) {
                                 if (traf.getTrackFragmentHeaderBox().getTrackId() == trackId) {


### PR DESCRIPTION
Merging multiple fragment files into a single unfragmented file did not work correctly, e.g. in `MostSimpleDashExample.java`. The media samples were correctly gathered from all fragments, but the movie fragment boxes of the additional fragments were ignored and not used to generate a valid sample table box, resulting in an invalid file that could not be handled by any major software I tested (VLC, MPC-HC, WMP, FFmpeg, Android MediaExtractor).
