### PR TITLE
Next three equals001 patch

### DIFF
--- a/isoparser/src/main/java/com/googlecode/mp4parser/authoring/tracks/H264TrackImpl.java
+++ b/isoparser/src/main/java/com/googlecode/mp4parser/authoring/tracks/H264TrackImpl.java
@@ -232,13 +232,11 @@ public class H264TrackImpl extends AbstractTrack {
                 return (buffer.get(inBufferPos) == 0 &&
                         buffer.get(inBufferPos + 1) == 0 &&
                         buffer.get(inBufferPos + 2) == 1);
-            } else {
-                if (bufferStartPos + inBufferPos == dataSource.size()) {
-                    throw new EOFException();
-                }
-                System.err.println(H264TrackImpl.this.samples.size());
-                throw new RuntimeException("buffer repositioning require");
             }
+            if (bufferStartPos + inBufferPos + 3 >= dataSource.size()) {
+                throw new EOFException();
+            }
+            return false;
         }
 
         boolean nextThreeEquals000or001orEof() throws IOException {


### PR DESCRIPTION
This appears to fix my issue that I posted in sannies/mp4parser#8  What I was seeing was that EOF was being reached but since it didn't align with 3 bytes from where the last sample was stored in the file it would blow up with the possition error.

I only tested this off of the 1.0.3.11 branch as that what builds safely for me.

The check seemed nonsensical to me in the context this method seems to always be called in.  I think always throwing EOF is more appropriate.
