### PR TITLE
Fixed: MemoryDataSource does not ever end .

### DIFF
--- a/isoparser/src/main/java/com/googlecode/mp4parser/MemoryDataSourceImpl.java
+++ b/isoparser/src/main/java/com/googlecode/mp4parser/MemoryDataSourceImpl.java
@@ -21,6 +21,9 @@ public class MemoryDataSourceImpl implements DataSource {
     }
 
     public int read(ByteBuffer byteBuffer) throws IOException {
+        if (0 == data.remaining() && 0 != byteBuffer.remaining()) {
+            return -1;
+        }
         byte[] buf = new byte[Math.min(byteBuffer.remaining(), data.remaining())];
         data.get(buf);
         byteBuffer.put(buf);


### PR DESCRIPTION
When reading data from a DataSource, test the return value is -1 to
determine end of stream.
But MemoryDataSourceImpl is return 0 at last, not return -1.
