### PR TITLE
Add a setter for chunk offsets.

### DIFF
--- a/isoparser/src/main/java/com/coremedia/iso/boxes/ChunkOffset64BitBox.java
+++ b/isoparser/src/main/java/com/coremedia/iso/boxes/ChunkOffset64BitBox.java
@@ -25,6 +25,11 @@ public class ChunkOffset64BitBox extends ChunkOffsetBox {
     }
 
     @Override
+    public void setChunkOffsets(long[] chunkOffsets) {
+        this.chunkOffsets = chunkOffsets;
+    }
+
+    @Override
     protected long getContentSize() {
         return 8 + 8 * chunkOffsets.length;
     }

--- a/isoparser/src/main/java/com/coremedia/iso/boxes/ChunkOffsetBox.java
+++ b/isoparser/src/main/java/com/coremedia/iso/boxes/ChunkOffsetBox.java
@@ -13,6 +13,7 @@ public abstract class ChunkOffsetBox extends AbstractFullBox {
 
     public abstract long[] getChunkOffsets();
 
+    public abstract void setChunkOffsets(long[] chunkOffsets);
 
     public String toString() {
         return this.getClass().getSimpleName() + "[entryCount=" + getChunkOffsets().length + "]";

--- a/isoparser/src/main/java/com/coremedia/iso/boxes/StaticChunkOffsetBox.java
+++ b/isoparser/src/main/java/com/coremedia/iso/boxes/StaticChunkOffsetBox.java
@@ -44,6 +44,7 @@ public class StaticChunkOffsetBox extends ChunkOffsetBox {
         return 8 + chunkOffsets.length * 4;
     }
 
+    @Override
     public void setChunkOffsets(long[] chunkOffsets) {
         this.chunkOffsets = chunkOffsets;
     }


### PR DESCRIPTION
The `co64` variant of the box is missing a setter. This pull request adds one to the superclass and implements it in `ChunkOffset64BitBox`.