### PR TITLE
Added support for Microsoft Windows Media Meta Data (Xtra) and Quicktime GPS Coordinates (©xyz)

### DIFF
--- a/examples/src/main/java/com/googlecode/mp4parser/stuff/MetaDataTool.java
+++ b/examples/src/main/java/com/googlecode/mp4parser/stuff/MetaDataTool.java
@@ -1,0 +1,271 @@
+package com.googlecode.mp4parser.stuff;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+
+import com.coremedia.iso.IsoFile;
+import com.coremedia.iso.boxes.Box;
+import com.coremedia.iso.boxes.ChunkOffsetBox;
+import com.coremedia.iso.boxes.Container;
+import com.coremedia.iso.boxes.MetaBox;
+import com.coremedia.iso.boxes.StaticChunkOffsetBox;
+import com.coremedia.iso.boxes.UnknownBox;
+import com.coremedia.iso.boxes.UserDataBox;
+import com.googlecode.mp4parser.boxes.apple.Utf8AppleDataBox;
+import com.googlecode.mp4parser.boxes.microsoft.XtraBox;
+import com.googlecode.mp4parser.util.Path;
+
+/**
+ * Hello world!
+ *
+ */
+public class MetaDataTool {
+	public static void main(String[] args) {
+		String file = "Z:\\temp\\moviestest\\dest.mp4";
+		try {
+			MetaDataTool mdt = new MetaDataTool( file );
+			mdt.dumpBoxes();
+		}
+		catch( Exception e ) {
+			e.printStackTrace();
+		}
+		System.err.println( "Hello!" );
+	}
+	
+	private long originalUserDataSize = 0;
+	private XtraBox xtraBox;
+	private UserDataBox userDataBox;
+	private MetaBox metaBox;
+	private IsoFile isoFile;
+	
+	public MetaDataTool( String path ) throws IOException {
+		
+		//The source I copied this from created 2 new files, a temp file and a target file
+		//I'm not sure this is necessary, but maybe when you make changes it's edited in-place?
+		//Anyway, just to be safe I'm keeping it so no operations are done on original file
+        File videoFile = new File(path);
+        if (!videoFile.exists())
+            throw new FileNotFoundException("File " + path + " not exists");
+
+        if (!videoFile.canWrite())
+            throw new IllegalStateException("No write permissions to file " + path);
+
+        File tempFile = File.createTempFile("ChangeMetaData", "");
+        FileUtils.copyFile(videoFile, tempFile);
+        tempFile.deleteOnExit();
+
+        isoFile = new IsoFile(tempFile.getAbsolutePath());
+        userDataBox = Path.getPath(isoFile, "/moov/udta");
+        if( userDataBox != null ) {
+        	originalUserDataSize = userDataBox.getSize();
+        }
+        
+	}
+	
+	public static final String WM_RATING_TAG = "WM/SharedUserRating";
+	public static final int WM_RATING_VALS[] = { 0, 1, 25, 50, 75, 99 };
+	public void setWindowsMediaRating( int rating ) { //0-5
+		if( rating < 0 || rating > 5 ) {
+			throw new RuntimeException( "Invalid rating, 0-5 only" );
+		}
+		
+		if( rating == 0 ) {
+			removeWindowsMediaTag( WM_RATING_TAG );
+		}
+		else {
+			setWindowsMediaLong( WM_RATING_TAG, WM_RATING_VALS[rating] );
+		}
+	}
+	
+	
+	public static final String WM_TAGS_TAG = "WM/Category";
+	public void setWindowsMediaTags( String tags[] ) {
+		if( tags == null || tags.length == 0 ) {
+			removeWindowsMediaTag( WM_TAGS_TAG );
+		}
+		else {
+			setWindowsMediaStrings( WM_TAGS_TAG, tags );
+		}
+	}
+	
+	public void setWindowsMediaDate( String tagName, Date dateVal ) {
+		XtraBox xb = getXtraBox();
+		xb.setTagValue( tagName, dateVal );
+	}
+
+	public void setWindowsMediaLong( String tagName, long longVal ) {
+		XtraBox xb = getXtraBox();
+		xb.setTagValue( tagName, longVal );
+	}
+	
+	public void setWindowsMediaStrings( String tagName, String values[] ) {
+		XtraBox xb = getXtraBox();
+		xb.setTagValues( tagName, values );
+	}
+	
+	public void removeWindowsMediaTag( String tagName ) {
+		XtraBox xb = getXtraBox();
+		xb.removeTag( tagName );
+	}
+	
+
+	private UserDataBox getUserDataBox() {
+		if( userDataBox == null ) {
+			userDataBox = new UserDataBox();
+			isoFile.getMovieBox().addBox( userDataBox );
+		}
+		return userDataBox;
+	}
+	
+	private MetaBox getMetaBox() {
+		if( metaBox == null ) {
+			UserDataBox ud = getUserDataBox();
+			metaBox = Path.getPath(ud, "meta");
+			if( metaBox == null ) {
+				metaBox = new MetaBox();
+                ud.addBox(metaBox);
+			}
+		}
+		return metaBox;
+	}
+	
+	private XtraBox getXtraBox() {
+		if( xtraBox == null ) {
+			UserDataBox ud = getUserDataBox(); //Create user data box if necessary
+			xtraBox = Path.getPath( ud, "Xtra" );
+			if( xtraBox == null ) {
+				xtraBox = new XtraBox();
+				ud.addBox( xtraBox );
+			}
+		}
+		return xtraBox;
+	}
+	
+	public void writeMp4( String filename ) throws IOException {
+        long finalUserDataSize = 0;
+		if( userDataBox != null ) {
+			finalUserDataSize = userDataBox.getSize();
+		}
+        if (needsOffsetCorrection(isoFile)) {
+            correctChunkOffsets(isoFile, finalUserDataSize - originalUserDataSize);
+        }
+        FileOutputStream videoFileOutputStream = null;
+        try {
+	        videoFileOutputStream = new FileOutputStream(filename);
+	        isoFile.getBox(videoFileOutputStream.getChannel());
+        }
+        finally {
+        	closeQuietly(isoFile);
+        	IOUtils.closeQuietly(videoFileOutputStream);
+        }
+	}
+	
+	private static String getIndentation( int indent ) {
+		char c[] = new char[indent];
+		for( int i = 0; i < indent; i++ ) {
+			c[i] = ' ';
+		}
+		return new String( c );
+	}
+	
+	public void dumpBoxes() {
+		dumpBoxes( isoFile, 0 );
+	}
+	
+	private static void dumpBoxes( Container container, int indent ) {
+		String meInd = getIndentation( indent );
+		String subInd = getIndentation( indent + 2 );
+		System.out.println( meInd +  container.getClass().getName() );
+		for (Box box : container.getBoxes() ) {
+	        	if( box instanceof Container ) {
+	        		dumpBoxes( (Container)box, indent + 2 );
+	        	}
+	        	else {
+	        		try {
+		        		if( box instanceof UnknownBox ) {
+		        			System.out.println( subInd + box.getClass().getName() + "[" + box.getSize() + "/" + box.getType() + "]:" + box.toString() );
+		        			UnknownBox ub = (UnknownBox)box;
+		        		}
+			        	else if( box instanceof Utf8AppleDataBox ) {
+		        			System.out.println( subInd + box.getClass().getName() + ": " + box.getType() + ": " + box.toString() + ": " + ((Utf8AppleDataBox)box).getValue() );
+			        	}
+			        	else {
+		        			System.out.println( subInd + box.getClass().getName() + ": " + box.getType() + ": " + box.toString() );
+			        	}
+	        		}
+	        		catch( Exception e ) {
+	        			System.err.println( "Error parsing " + box.getClass().getSimpleName() + " box: " + e );
+	        			e.printStackTrace( System.err );
+	        		}
+    		}
+        }
+	}
+
+    public static boolean needsOffsetCorrection(IsoFile isoFile) {
+
+        if (Path.getPaths(isoFile, "mdat").size() > 1) {
+            throw new RuntimeException("There might be the weird case that a file has two mdats. One before" +
+                    " moov and one after moov. That would need special handling therefore I just throw an " +
+                    "exception here. ");
+        }
+
+        if (Path.getPaths(isoFile, "moof").size() > 0) {
+            throw new RuntimeException("Fragmented MP4 files need correction, too. (But I would need to look where)");
+        }
+
+        for (Box box : isoFile.getBoxes()) {
+            if ("mdat".equals(box.getType())) {
+                return false;
+            }
+            if ("moov".equals(box.getType())) {
+                return true;
+            }
+        }
+        throw new RuntimeException("Hmmm - shouldn't happen");
+    }
+
+    private static void correctChunkOffsets(IsoFile tempIsoFile, long correction) {
+        List<Box> chunkOffsetBoxes = Path.getPaths(tempIsoFile, "/moov[0]/trak/mdia[0]/minf[0]/stbl[0]/stco[0]");
+        for (Box chunkOffsetBox : chunkOffsetBoxes) {
+
+            LinkedList<Box> stblChildren = new LinkedList<Box>(chunkOffsetBox.getParent().getBoxes());
+            stblChildren.remove(chunkOffsetBox);
+
+            long[] cOffsets = ((ChunkOffsetBox) chunkOffsetBox).getChunkOffsets();
+            for (int i = 0; i < cOffsets.length; i++) {
+                cOffsets[i] += correction;
+            }
+
+            StaticChunkOffsetBox cob = new StaticChunkOffsetBox();
+            cob.setChunkOffsets(cOffsets);
+            stblChildren.add(cob);
+            chunkOffsetBox.getParent().setBoxes(stblChildren);
+        }
+    }
+    public static void deleteQuietly( File f ) {
+    	try {
+    		f.delete();
+    	}
+    	catch( Exception ioe ) {
+    		//ignore
+    	}
+    }
+    public static void closeQuietly(IsoFile input) {
+        try {
+            if (input != null) {
+                input.close();
+            }
+        } catch (IOException ioe) {
+            // ignore
+        }
+    }
+
+}

--- a/isoparser/src/main/java/com/googlecode/mp4parser/boxes/apple/AppleGPSCoordinatesBox.java
+++ b/isoparser/src/main/java/com/googlecode/mp4parser/boxes/apple/AppleGPSCoordinatesBox.java
@@ -1,0 +1,45 @@
+package com.googlecode.mp4parser.boxes.apple;
+
+import java.nio.ByteBuffer;
+
+import com.coremedia.iso.Ascii;
+import com.googlecode.mp4parser.AbstractBox;
+
+/**
+ * Created by sannies on 10/15/13.
+ */
+public class AppleGPSCoordinatesBox extends AbstractBox {
+    public AppleGPSCoordinatesBox() {
+        super("©alb");
+    }
+
+    String coords;
+    
+	@Override
+	protected long getContentSize() {
+		return coords.length();
+	}
+
+	@Override
+	protected void getContent(ByteBuffer byteBuffer) {
+		// TODO Auto-generated method stub
+		byteBuffer.putInt( coords.length( ) );
+		byteBuffer.put( Ascii.convert( coords ) );
+	}
+
+	@Override
+	protected void _parseDetails(ByteBuffer content) {
+		int length = content.getInt();
+		byte bytes[] = new byte[length];
+		content.get( bytes );
+		coords = Ascii.convert( bytes );
+	}
+    
+	public String toString() {
+		if( !isParsed() ) {
+			parseDetails();
+		}
+		return "AppleGPSCoordinatesBox[" + coords + "]";
+	}
+	
+}

--- a/isoparser/src/main/java/com/googlecode/mp4parser/boxes/apple/AppleGPSCoordinatesBox.java
+++ b/isoparser/src/main/java/com/googlecode/mp4parser/boxes/apple/AppleGPSCoordinatesBox.java
@@ -2,43 +2,54 @@ package com.googlecode.mp4parser.boxes.apple;
 
 import java.nio.ByteBuffer;
 
-import com.coremedia.iso.Ascii;
+import com.coremedia.iso.Utf8;
 import com.googlecode.mp4parser.AbstractBox;
 
 /**
- * Created by sannies on 10/15/13.
+ * Created by marwatk on 02/27/15
  */
 public class AppleGPSCoordinatesBox extends AbstractBox {
-    public AppleGPSCoordinatesBox() {
-        super("©alb");
-    }
-
-    String coords;
+    public static final String TYPE = "©xyz";
+	private static final int DEFAULT_LANG = 5575; //Empirical
     
+    String coords;
+    int lang = DEFAULT_LANG; //? Docs says lang, but it doesn't match anything in the traditional language map
+	
+	public AppleGPSCoordinatesBox() {
+        super( TYPE );
+    }
+    
+	public String getValue() {
+		return coords;
+	}
+	
+	public void setValue( String iso6709String ) {
+		lang = DEFAULT_LANG;
+		coords = iso6709String;
+	}
+	
 	@Override
 	protected long getContentSize() {
-		return coords.length();
+		return 4 + Utf8.utf8StringLengthInBytes( coords );
 	}
 
 	@Override
 	protected void getContent(ByteBuffer byteBuffer) {
-		// TODO Auto-generated method stub
-		byteBuffer.putInt( coords.length( ) );
-		byteBuffer.put( Ascii.convert( coords ) );
+		byteBuffer.putShort( (short)coords.length( ) );
+		byteBuffer.putShort( (short)lang );
+		byteBuffer.put( Utf8.convert( coords ) );
 	}
 
 	@Override
 	protected void _parseDetails(ByteBuffer content) {
-		int length = content.getInt();
+		int length = content.getShort();
+        lang = content.getShort(); //Not sure if this is accurate. It always seems to be 15 c7
 		byte bytes[] = new byte[length];
 		content.get( bytes );
-		coords = Ascii.convert( bytes );
+		coords = Utf8.convert( bytes );
 	}
     
 	public String toString() {
-		if( !isParsed() ) {
-			parseDetails();
-		}
 		return "AppleGPSCoordinatesBox[" + coords + "]";
 	}
 	

--- a/isoparser/src/main/java/com/googlecode/mp4parser/boxes/apple/AppleNameBox.java
+++ b/isoparser/src/main/java/com/googlecode/mp4parser/boxes/apple/AppleNameBox.java
@@ -4,7 +4,8 @@ package com.googlecode.mp4parser.boxes.apple;
  * Created by sannies on 10/15/13.
  */
 public class AppleNameBox extends Utf8AppleDataBox {
-    public AppleNameBox() {
-        super("©nam");
+    public static final String TYPE = "©nam";
+	public AppleNameBox() {
+        super( TYPE );
     }
 }

--- a/isoparser/src/main/java/com/googlecode/mp4parser/boxes/microsoft/XtraBox.java
+++ b/isoparser/src/main/java/com/googlecode/mp4parser/boxes/microsoft/XtraBox.java
@@ -1,0 +1,546 @@
+/*  
+ * Copyright 2008 CoreMedia AG, Hamburg
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at 
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an AS IS BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+
+package com.googlecode.mp4parser.boxes.microsoft;
+
+
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Date;
+import java.util.Vector;
+
+import com.googlecode.mp4parser.AbstractBox;
+
+
+
+/**
+ * @author marwatk
+ * <h1>4cc = "{@value #TYPE}"</h1>
+ * Windows Media Xtra Box.
+ * 
+ * I can't find definitive documentation on this from Microsoft so it's cobbled together from
+ * various sources. Mostly ExifTool for Perl.
+ * 
+ * Various references:
+ * https://msdn.microsoft.com/en-us/library/windows/desktop/dd743066(v=vs.85).aspx
+ * https://metacpan.org/source/EXIFTOOL/Image-ExifTool-9.76/lib/Image/ExifTool/Microsoft.pm
+ * http://www.ventismedia.com/mantis/view.php?id=12017
+ * http://www.hydrogenaudio.org/forums/index.php?showtopic=75123&st=250
+ * http://www.mediamonkey.com/forum/viewtopic.php?f=1&t=76321
+ * https://code.google.com/p/mp4v2/issues/detail?id=113
+ * 
+ * Basic structure:
+ * 
+ * 
+ */
+
+public class XtraBox extends AbstractBox {
+    public static final String TYPE = "Xtra";
+
+	public static final int MP4_XTRA_BT_UNICODE   =  8;
+	public static final int MP4_XTRA_BT_INT64     = 19;
+	public static final int MP4_XTRA_BT_FILETIME  = 21;
+	public static final int MP4_XTRA_BT_GUID      = 72;
+
+	private boolean successfulParse = false;
+	
+	Vector<XtraTag> tags = new Vector<XtraTag>();
+	
+	ByteBuffer data;
+
+    public XtraBox() {
+    	super( "Xtra" );
+    	
+    }
+    public XtraBox(String type) {
+        super(type);
+    }
+
+    @Override
+    protected long getContentSize() {
+        if( successfulParse ) {
+        	return detailSize();
+        }
+        else {
+        	return data.limit();
+        }
+    }
+    
+    private int detailSize() {
+    	int size = 0;
+    	for( int i = 0; i < tags.size(); i++ ) {
+    		size += tags.elementAt( i ).getContentSize();
+    	}
+    	return size;
+    	
+    }
+    
+    public String toString() {
+    	if( !this.isParsed() ) {
+    		this.parseDetails();
+    	}
+    	StringBuffer b = new StringBuffer();
+    	b.append( "XtraBox[" );
+    	for( XtraTag tag : tags ) {
+    		for( XtraValue value : tag.values ) {
+    			b.append( tag.tagName );
+    			b.append( "=" );
+    			b.append( value.toString() );
+    			b.append( ";" );
+    		}
+    	}
+    	b.append( "]" );
+    	return b.toString();
+    }
+
+    @Override
+    public void _parseDetails(ByteBuffer content) {
+        int boxSize = content.remaining();
+    	data = content.slice(); //Keep this in case we fail to parse
+    	successfulParse = false;
+    	try {
+	    	tags.clear();
+	        while( content.remaining() > 0 ) {
+	        	XtraTag tag = new XtraTag();
+	        	tag.parse( content );
+	        	tags.addElement( tag );
+	        }
+	        if( boxSize != detailSize() ) {
+        		throw new RuntimeException( "Improperly handled Xtra tag: Overall sizes don't match ( " + boxSize + "/" + detailSize() + ")" );
+	        }
+	        successfulParse = true;
+    	}
+    	catch( Exception e ) {
+    		successfulParse = false;
+    		System.err.println( "Malformed Xtra Tag detected: " + e.toString() );
+            content.position(content.position() + content.remaining());
+    	}
+    	finally {
+        	content.order( ByteOrder.BIG_ENDIAN ); //Just in case we bailed out mid-parse we don't want to leave the byte order in MS land
+    	}
+    }
+    @Override
+    protected void getContent(ByteBuffer byteBuffer) {
+        if( successfulParse ) {
+        	for( int i = 0; i < tags.size(); i++ ) {
+				tags.elementAt( i ).getContent( byteBuffer );
+        	}
+        }
+        else {
+        	data.rewind();
+        	byteBuffer.put(data);
+        }
+    }
+
+    /**
+     * Returns a list of the tag names present in this Xtra Box
+     * @return Possibly empty (zero length) array of tag names present
+     */
+    public String[] getAllTagNames() {
+    	String names[] = new String[tags.size()];
+    	for( int i = 0; i < tags.size(); i++ ) {
+    		XtraTag tag = tags.elementAt( i );
+    		names[i] = tag.tagName;
+    	}
+    	return names;
+    }
+    
+    /**
+     * Returns the first String value found for this tag
+     * @param name Tag name
+     * @return First String value found
+     */
+    public String getFirstStringValue( String name ) {
+    	Object objs[] = getValues( name );
+    	for( Object obj : objs ) {
+    		if( obj instanceof String ) {
+    			return (String)obj;
+    		}
+    	}
+    	return null;
+    }
+    
+    
+    /**
+     * Returns the first Date value found for this tag
+     * @param name Tag name
+     * @return First Date value found
+     */
+    public Date getFirstDateValue( String name ) {
+    	Object objs[] = getValues( name );
+    	for( Object obj : objs ) {
+    		if( obj instanceof Date ) {
+    			return (Date)obj;
+    		}
+    	}
+    	return null;
+    }
+    
+    
+    /**
+     * Returns the first Long value found for this tag
+     * @param name Tag name
+     * @return First long value found
+     */
+    public Long getFirstLongValue( String name ) {
+    	Object objs[] = getValues( name );
+    	for( Object obj : objs ) {
+    		if( obj instanceof Long ) {
+    			return (Long)obj;
+    		}
+    	}
+    	return null;
+    }
+    
+    /**
+     * Returns an array of values for this tag. Empty array when tag is not present
+     * @param name Tag name to retrieve
+     * @return Possibly empty array of values (possible types are String, Long, Date and byte[] )
+     */
+    public Object[] getValues( String name ) {
+    	XtraTag tag = getTagByName( name );
+    	Object values[];
+    	if( tag != null ) {
+    		values = new Object[tag.values.size()];
+        	for( int i = 0; i < tag.values.size(); i++ ) {
+        		values[i] = tag.values.elementAt( i ).getValueAsObject();
+        	}
+    	}
+    	else {
+    		values = new Object[0];
+    	}
+    	return values;
+    }
+    
+    
+    /**
+     * Removes specified tag (all values for that tag will be removed)
+     * @param name Tag to remove
+     */
+    public void removeTag( String name ) {
+    	XtraTag tag = getTagByName( name );
+    	if( tag != null ) {
+    		tags.remove( tag );
+    	}
+    }
+    
+    /**
+     * Removes and recreates tag using specified String values
+     * 
+     * @param name Tag name to replace
+     * @param values New String values
+     */
+    public void setTagValues( String name, String values[] ) {
+    	removeTag( name );
+    	XtraTag tag = new XtraTag( name );
+    	for( int i = 0; i < values.length; i++ ) {
+    		tag.values.addElement( new XtraValue( values[i] ) );
+    	}
+    	tags.addElement( tag );
+    }
+    
+    
+    /**
+     * Removes and recreates tag using specified String value
+     * 
+     * @param name Tag name to replace
+     * @param values New String value
+     */
+    public void setTagValue( String name, String value ) {
+    	setTagValues( name, new String[] { value } );
+    }
+    
+    
+    /**
+     * Removes and recreates tag using specified Date value
+     * 
+     * @param name Tag name to replace
+     * @param values New Date value
+     */
+    public void setTagValue( String name, Date date ) {
+    	removeTag( name );
+    	XtraTag tag = new XtraTag( name );
+		tag.values.addElement( new XtraValue( date ) );
+    	tags.addElement( tag );
+    }
+    
+    /**
+     * Removes and recreates tag using specified Long value
+     * 
+     * @param name Tag name to replace
+     * @param values New Long value
+     */
+    public void setTagValue( String name, long value ) {
+    	removeTag( name );
+    	XtraTag tag = new XtraTag( name );
+		tag.values.addElement( new XtraValue( value ) );
+    	tags.addElement( tag );
+    }
+    
+    private XtraTag getTagByName( String name ) {
+    	for( XtraTag tag : tags ) {
+    		if( tag.tagName.equals( name ) ) {
+    			return tag;
+    		}
+    	}
+    	return null;
+    }
+
+    private static class XtraTag {
+    	private int inputSize; //For debugging only
+    	
+    	private String tagName;
+    	private Vector<XtraValue> values;
+    	
+    	private XtraTag() {
+    		values = new Vector<XtraValue>();
+    	}
+    	private XtraTag(String name) {
+    		this();
+    		tagName = name;
+    	}
+    	
+    	private void parse( ByteBuffer content ) {
+        	inputSize = content.getInt();
+        	int tagLength = content.getInt();
+        	tagName = readAsciiString( content, tagLength );
+        	int count = content.getInt();
+        	
+        	for( int i = 0; i < count; i++ ) {
+        		XtraValue val = new XtraValue();
+        		val.parse( content );
+        		values.addElement( val );
+        	}
+        	if( inputSize != getContentSize() ) {
+        		throw new RuntimeException( "Improperly handled Xtra tag: Sizes don't match ( " + inputSize + "/" + getContentSize() + ") on " + tagName );
+        	}
+    	}
+		private void getContent( ByteBuffer b ) {
+			b.putInt( getContentSize() );
+			b.putInt( tagName.length() );
+			writeAsciiString( b, tagName );
+			b.putInt( values.size() );
+			for( int i = 0; i < values.size(); i++ ) {
+				values.elementAt( i ).getContent( b );
+			}
+		}
+    	private int getContentSize() {
+    		//Size: 4
+    		//TagLength: 4
+    		//Tag: tagLength;
+    		//Count: 4
+    		//Values: count * values.getContentSize();
+    		int size = 12 + tagName.length();
+    		for( int i = 0; i < values.size(); i++ ) {
+    			size += values.elementAt( i ).getContentSize();
+    		}
+    		return size;
+    	}
+    	public String toString() {
+    		StringBuffer b = new StringBuffer();
+    		b.append( tagName );
+    		b.append( " [" );
+    		b.append( inputSize );
+    		b.append( "/" );
+    		b.append( values.size() );
+    		b.append( "]:\n" );
+    		for( int i = 0; i < values.size(); i++ ) {
+    			b.append( "  " );
+    			b.append( values.elementAt( i ).toString() );
+    			b.append( "\n" );
+    		}
+    		return b.toString();
+    	}
+    	
+    }
+
+    
+    private static class XtraValue {
+    	public int length;
+    	public int type;
+
+    	public String stringValue;
+    	public long longValue;
+    	public byte[] nonParsedValue;
+    	public Date fileTimeValue;
+    	
+    	private XtraValue() {
+    		
+    	}
+    	
+    	private XtraValue( String val ) {
+    		type = MP4_XTRA_BT_UNICODE;
+    		stringValue = val;
+    	}
+    	private XtraValue( long longVal ) {
+    		type = MP4_XTRA_BT_INT64;
+    		longValue = longVal;
+    	}
+    	private XtraValue( Date time ) {
+    		type = MP4_XTRA_BT_FILETIME;
+    		fileTimeValue = time;
+    	}
+    	
+    	private Object getValueAsObject() {
+    		switch( type ) {
+			case MP4_XTRA_BT_UNICODE:
+				return stringValue;
+			case MP4_XTRA_BT_INT64:
+				return new Long( longValue );
+			case MP4_XTRA_BT_FILETIME:
+				return fileTimeValue;
+			case MP4_XTRA_BT_GUID:
+			default:
+				return nonParsedValue;
+    		}
+    	}
+    	
+		private void parse(ByteBuffer content) {
+    		length = content.getInt() - 6;
+    		type = content.getShort();
+        	content.order( ByteOrder.LITTLE_ENDIAN);
+    		switch( type ) {
+    			case MP4_XTRA_BT_UNICODE:
+    				stringValue = readUtf16String( content, length );
+    				break;
+    			case MP4_XTRA_BT_INT64:
+    				longValue = content.getLong();
+    				break;
+    			case MP4_XTRA_BT_FILETIME:
+    				fileTimeValue = new Date( filetimeToMillis(content.getLong()) );
+    				break;
+    			case MP4_XTRA_BT_GUID:
+    			default:
+    				nonParsedValue = new byte[length];
+    				content.get( nonParsedValue );
+    				break;
+    		
+    		}
+        	content.order( ByteOrder.BIG_ENDIAN );
+			
+		}
+    	
+		private void getContent( ByteBuffer b ) {
+			try {
+				b.putInt( length );
+				b.putShort( (short)type );
+	        	b.order( ByteOrder.LITTLE_ENDIAN);
+	    		switch( type ) {
+					case MP4_XTRA_BT_UNICODE:
+						writeUtf16String( b, stringValue );
+						break;
+					case MP4_XTRA_BT_INT64:
+						b.putLong( longValue );
+						break;
+					case MP4_XTRA_BT_FILETIME:
+						b.putLong( millisToFiletime( fileTimeValue.getTime() ) );
+						break;
+					case MP4_XTRA_BT_GUID:
+					default:
+						b.put( nonParsedValue );
+						break;
+	    		}
+			}
+			finally {
+	        	b.order( ByteOrder.BIG_ENDIAN );
+			}
+		}
+    	private int getContentSize() {
+    		//Length: 4 bytes
+    		//Type: 2 bytes
+    		//Content: length bytes
+    		int size = 6;
+    		
+    		switch( type ) {
+				case MP4_XTRA_BT_UNICODE:
+					size += ( stringValue.length() * 2 ) + 2; //Plus 2 for trailing null
+					break;
+				case MP4_XTRA_BT_INT64:
+				case MP4_XTRA_BT_FILETIME:
+					size += 8;
+					break;
+				case MP4_XTRA_BT_GUID:
+				default:
+					size += nonParsedValue.length;
+					break;
+    		}
+    		return size;
+    	}
+    	
+    	public String toString() {
+    		switch( type ) {
+				case MP4_XTRA_BT_UNICODE:
+					return stringValue;
+				case MP4_XTRA_BT_INT64:
+					return String.valueOf( longValue );
+				case MP4_XTRA_BT_FILETIME:
+					return fileTimeValue.toString();
+				case MP4_XTRA_BT_GUID:
+				default:
+					return "(nonParsed)";
+    		
+    		}
+    	}
+    	
+    }
+    
+
+	//http://stackoverflow.com/questions/5398557/java-library-for-dealing-with-win32-filetime
+	private static final long FILETIME_EPOCH_DIFF = 11644473600000L;
+	private static final long FILETIME_ONE_MILLISECOND = 10 * 1000;
+    private static long filetimeToMillis(final long filetime) {
+        return (filetime / FILETIME_ONE_MILLISECOND) - FILETIME_EPOCH_DIFF;
+    }
+    private static long millisToFiletime(final long millis) {
+        return (millis + FILETIME_EPOCH_DIFF) * FILETIME_ONE_MILLISECOND;
+    }
+    
+    private static void writeAsciiString( ByteBuffer dest, String s ) {
+		try {
+			dest.put( s.getBytes( "US-ASCII" ) );
+		} catch (UnsupportedEncodingException e) {
+			throw new RuntimeException( "Shouldn't happen", e );
+		}
+    }
+    private static String readAsciiString( ByteBuffer content, int length ) {
+    	byte s[] = new byte[length];
+    	content.get( s );
+    	try {
+			return new String( s, "US-ASCII" );
+		} catch (UnsupportedEncodingException e) {
+			throw new RuntimeException( "Shouldn't happen", e );
+		}
+    }
+    
+    
+    private static String readUtf16String( ByteBuffer content, int length ) {
+    	char s[] = new char[(length/2)-1];
+    	for( int i = 0; i < (length/2)-1; i++ ) {
+    		s[i] = content.getChar();
+    	}
+    	content.getChar(); //Discard terminating null
+    	return new String( s );
+    }    
+    private static void writeUtf16String( ByteBuffer dest, String s ) {
+    	char ar[] = s.toCharArray();
+    	for( int i = 0; i < ar.length; i++ ) { //Probably not the best way to do this but it preserves the byte order
+    		dest.putChar( ar[i] );
+    	}
+    	dest.putChar( (char)0 ); //Terminating null
+    }  
+
+}

--- a/isoparser/src/main/resources/isoparser-default.properties
+++ b/isoparser/src/main/resources/isoparser-default.properties
@@ -256,3 +256,8 @@ saiz=com.mp4parser.iso14496.part12.SampleAuxiliaryInformationSizesBox
 vttC=com.mp4parser.iso14496.part30.WebVTTConfigurationBox
 vlab=com.mp4parser.iso14496.part30.WebVTTSourceLabelBox
 wvtt=com.mp4parser.iso14496.part30.WebVTTSampleEntry
+
+
+#added by marwatk (2/24/2014)
+Xtra=com.googlecode.mp4parser.boxes.microsoft.XtraBox
+\u00A9xyz=com.googlecode.mp4parser.boxes.apple.AppleGPSCoordinatesBox


### PR DESCRIPTION
We use Windows Live Photo Gallery for maintaining our home movies and it uses a proprietary atom for storing tags, ratings, etc. This push adds support for those tags, as well as Quicktime GPS Coordinates.

I also wrote another example based on the ChangeMetaData example that allows for editing of the windows specific meta data. There's also a minor change to AppleNameBox to facilitate changing titles without hard coding the box type.