### PR TITLE
squid:S2325 private methods that don't access instance data should be static

### DIFF
--- a/muxer/src/main/java/org/mp4parser/muxer/builder/FragmentedMp4Builder.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/builder/FragmentedMp4Builder.java
@@ -715,7 +715,7 @@ public class FragmentedMp4Builder implements Mp4Builder {
         return tkhd;
     }
 
-    private long getTrackDuration(Movie movie, Track track) {
+    private static long getTrackDuration(Movie movie, Track track) {
         return (track.getDuration() * movie.getTimescale()) / track.getTrackMetaData().getTimescale();
     }
 

--- a/muxer/src/main/java/org/mp4parser/muxer/tracks/AC3TrackImpl.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/tracks/AC3TrackImpl.java
@@ -453,7 +453,7 @@ public class AC3TrackImpl extends AbstractTrack {
         return audioSampleEntry;
     }
 
-    private int getFrameSize(int code, int fscod) {
+    private static int getFrameSize(int code, int fscod) {
         int frmsizecode = code >>> 1;
         int flag = code & 1;
         if (frmsizecode > 18 || flag > 1 || fscod > 2) {

--- a/muxer/src/main/java/org/mp4parser/muxer/tracks/DTSTrackImpl.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/tracks/DTSTrackImpl.java
@@ -673,7 +673,7 @@ public class DTSTrackImpl extends AbstractTrack {
         return mySamples;
     }
 
-    private int getBitRate(int rate) throws IOException {
+    private static int getBitRate(int rate) throws IOException {
         int bitrate;
         switch (rate)
 
@@ -789,7 +789,7 @@ public class DTSTrackImpl extends AbstractTrack {
         return bitrate;
     }
 
-    private int getSampleRate(int sfreq) throws IOException {
+    private static int getSampleRate(int sfreq) throws IOException {
         int samplerate;
         switch (sfreq)
 

--- a/muxer/src/main/java/org/mp4parser/muxer/tracks/h264/parsing/model/SeqParameterSet.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/tracks/h264/parsing/model/SeqParameterSet.java
@@ -504,7 +504,7 @@ public class SeqParameterSet extends BitstreamElement {
 
     }
 
-    private void writeHRDParameters(HRDParameters hrd, CAVLCWriter writer)
+    private static void writeHRDParameters(HRDParameters hrd, CAVLCWriter writer)
             throws IOException {
         writer.writeUE(hrd.cpb_cnt_minus1, "HRD: cpb_cnt_minus1");
         writer.writeNBit(hrd.bit_rate_scale, 4, "HRD: bit_rate_scale");

--- a/muxer/src/main/java/org/mp4parser/muxer/tracks/h265/SequenceParameterSetRbsp.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/tracks/h265/SequenceParameterSetRbsp.java
@@ -71,7 +71,7 @@ public class SequenceParameterSetRbsp {
         }
     }
 
-    private void scaling_list_data(CAVLCReader bsr) throws IOException {
+    private static void scaling_list_data(CAVLCReader bsr) throws IOException {
         boolean[][] scaling_list_pred_mode_flag = new boolean[4][];
         int[][] scaling_list_pred_matrix_id_delta = new int[4][];
         int[][] scaling_list_dc_coef_minus8 = new int[2][];
@@ -104,7 +104,7 @@ public class SequenceParameterSetRbsp {
     }
 
 
-    private void profile_tier_level(int maxNumSubLayersMinus1, CAVLCReader bsr) throws IOException {
+    private static void profile_tier_level(int maxNumSubLayersMinus1, CAVLCReader bsr) throws IOException {
         int general_profile_space = bsr.readU(2, "general_profile_space");
         boolean general_tier_flag = bsr.readBool("general_tier_flag");
         int general_profile_idc = bsr.readU(5, "general_profile_idc");


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S2325 private methods that don't access instance data should be static.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2325
Please let me know if you have any questions.
George Kankava