### PR TITLE
squid:S1192 String literals should not be duplicated

### DIFF
--- a/muxer/src/main/java/org/mp4parser/muxer/tracks/AACTrackImpl.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/tracks/AACTrackImpl.java
@@ -36,6 +36,7 @@ import java.util.*;
  */
 public class AACTrackImpl extends AbstractTrack {
 
+    private static final String RESERVED = "Reserved";
     public static Map<Integer, Integer> samplingFrequencyIndexMap = new HashMap<Integer, Integer>();
     static Map<Integer, String> audioObjectTypes = new HashMap<Integer, String>();
 
@@ -49,15 +50,15 @@ public class AACTrackImpl extends AbstractTrack {
         audioObjectTypes.put(7, "TwinVQ");
         audioObjectTypes.put(8, "CELP (Code Excited Linear Prediction)");
         audioObjectTypes.put(9, "HXVC (Harmonic Vector eXcitation Coding)");
-        audioObjectTypes.put(10, "Reserved");
-        audioObjectTypes.put(11, "Reserved");
+        audioObjectTypes.put(10, RESERVED);
+        audioObjectTypes.put(11, RESERVED);
         audioObjectTypes.put(12, "TTSI (Text-To-Speech Interface)");
         audioObjectTypes.put(13, "Main Synthesis");
         audioObjectTypes.put(14, "Wavetable Synthesis");
         audioObjectTypes.put(15, "General MIDI");
         audioObjectTypes.put(16, "Algorithmic Synthesis and Audio Effects");
         audioObjectTypes.put(17, "ER (Error Resilient) AAC LC");
-        audioObjectTypes.put(18, "Reserved");
+        audioObjectTypes.put(18, RESERVED);
         audioObjectTypes.put(19, "ER AAC LTP");
         audioObjectTypes.put(20, "ER AAC Scalable");
         audioObjectTypes.put(21, "ER TwinVQ");

--- a/muxer/src/main/java/org/mp4parser/muxer/tracks/h264/parsing/model/PictureParameterSet.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/tracks/h264/parsing/model/PictureParameterSet.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
  */
 public class PictureParameterSet extends BitstreamElement {
 
+    private static final String PPS = "PPS: ";
     public boolean entropy_coding_mode_flag;
     public int num_ref_idx_l0_active_minus1;
     public int num_ref_idx_l1_active_minus1;
@@ -185,12 +186,12 @@ public class PictureParameterSet extends BitstreamElement {
             int[] run_length_minus1 = new int[1];
             if (slice_group_map_type == 0) {
                 for (int iGroup = 0; iGroup <= num_slice_groups_minus1; iGroup++) {
-                    writer.writeUE(run_length_minus1[iGroup], "PPS: ");
+                    writer.writeUE(run_length_minus1[iGroup], PPS);
                 }
             } else if (slice_group_map_type == 2) {
                 for (int iGroup = 0; iGroup < num_slice_groups_minus1; iGroup++) {
-                    writer.writeUE(top_left[iGroup], "PPS: ");
-                    writer.writeUE(bottom_right[iGroup], "PPS: ");
+                    writer.writeUE(top_left[iGroup], PPS);
+                    writer.writeUE(bottom_right[iGroup], PPS);
                 }
             } else if (slice_group_map_type == 3 || slice_group_map_type == 4
                     || slice_group_map_type == 5) {
@@ -206,7 +207,7 @@ public class PictureParameterSet extends BitstreamElement {
                     NumberBitsPerSliceGroupId = 2;
                 else
                     NumberBitsPerSliceGroupId = 1;
-                writer.writeUE(slice_group_id.length, "PPS: ");
+                writer.writeUE(slice_group_id.length, PPS);
                 for (int i = 0; i <= slice_group_id.length; i++) {
                     writer.writeU(slice_group_id[i], NumberBitsPerSliceGroupId);
                 }
@@ -239,7 +240,7 @@ public class PictureParameterSet extends BitstreamElement {
                         writer
                                 .writeBool(
                                         extended.scalindMatrix.ScalingList4x4[i] != null,
-                                        "PPS: ");
+                                        PPS);
                         if (extended.scalindMatrix.ScalingList4x4[i] != null) {
                             extended.scalindMatrix.ScalingList4x4[i]
                                     .write(writer);
@@ -249,7 +250,7 @@ public class PictureParameterSet extends BitstreamElement {
                         writer
                                 .writeBool(
                                         extended.scalindMatrix.ScalingList8x8[i - 6] != null,
-                                        "PPS: ");
+                                        PPS);
                         if (extended.scalindMatrix.ScalingList8x8[i - 6] != null) {
                             extended.scalindMatrix.ScalingList8x8[i - 6]
                                     .write(writer);
@@ -257,7 +258,7 @@ public class PictureParameterSet extends BitstreamElement {
                     }
                 }
             }
-            writer.writeSE(extended.second_chroma_qp_index_offset, "PPS: ");
+            writer.writeSE(extended.second_chroma_qp_index_offset, PPS);
         }
 
         writer.writeTrailingBits();

--- a/muxer/src/main/java/org/mp4parser/muxer/tracks/h264/parsing/model/SeqParameterSet.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/tracks/h264/parsing/model/SeqParameterSet.java
@@ -36,6 +36,9 @@ import java.io.OutputStream;
  * @author Stanislav Vitvitskiy
  */
 public class SeqParameterSet extends BitstreamElement {
+    private static final String HRD = "HRD: ";
+    private static final String VUI = "VUI: ";
+    private static final String SPS = "SPS: ";
     public int pic_order_cnt_type;
     public boolean field_pic_flag;
     public boolean delta_pic_order_always_zero_flag;
@@ -340,24 +343,24 @@ public class SeqParameterSet extends BitstreamElement {
                 writer.writeBool(residual_color_transform_flag,
                         "SPS: residual_color_transform_flag");
             }
-            writer.writeUE(bit_depth_luma_minus8, "SPS: ");
-            writer.writeUE(bit_depth_chroma_minus8, "SPS: ");
+            writer.writeUE(bit_depth_luma_minus8, SPS);
+            writer.writeUE(bit_depth_chroma_minus8, SPS);
             writer.writeBool(qpprime_y_zero_transform_bypass_flag,
                     "SPS: qpprime_y_zero_transform_bypass_flag");
-            writer.writeBool(scalingMatrix != null, "SPS: ");
+            writer.writeBool(scalingMatrix != null, SPS);
             if (scalingMatrix != null) {
                 for (int i = 0; i < 8; i++) {
                     if (i < 6) {
                         writer.writeBool(
                                 scalingMatrix.ScalingList4x4[i] != null,
-                                "SPS: ");
+                                SPS);
                         if (scalingMatrix.ScalingList4x4[i] != null) {
                             scalingMatrix.ScalingList4x4[i].write(writer);
                         }
                     } else {
                         writer.writeBool(
                                 scalingMatrix.ScalingList8x8[i - 6] != null,
-                                "SPS: ");
+                                SPS);
                         if (scalingMatrix.ScalingList8x8[i - 6] != null) {
                             scalingMatrix.ScalingList8x8[i - 6].write(writer);
                         }
@@ -378,9 +381,9 @@ public class SeqParameterSet extends BitstreamElement {
                     "SPS: offset_for_non_ref_pic");
             writer.writeSE(offset_for_top_to_bottom_field,
                     "SPS: offset_for_top_to_bottom_field");
-            writer.writeUE(offsetForRefFrame.length, "SPS: ");
+            writer.writeUE(offsetForRefFrame.length, SPS);
             for (int i = 0; i < offsetForRefFrame.length; i++)
-                writer.writeSE(offsetForRefFrame[i], "SPS: ");
+                writer.writeSE(offsetForRefFrame[i], SPS);
         }
         writer.writeUE(num_ref_frames, "SPS: num_ref_frames");
         writer.writeBool(gaps_in_frame_num_value_allowed_flag,
@@ -405,7 +408,7 @@ public class SeqParameterSet extends BitstreamElement {
             writer.writeUE(frame_crop_bottom_offset,
                     "SPS: frame_crop_bottom_offset");
         }
-        writer.writeBool(vuiParams != null, "SPS: ");
+        writer.writeBool(vuiParams != null, SPS);
         if (vuiParams != null)
             writeVUIParameters(vuiParams, writer);
 
@@ -464,11 +467,11 @@ public class SeqParameterSet extends BitstreamElement {
             writer.writeBool(vuip.fixed_frame_rate_flag,
                     "VUI: fixed_frame_rate_flag");
         }
-        writer.writeBool(vuip.nalHRDParams != null, "VUI: ");
+        writer.writeBool(vuip.nalHRDParams != null, VUI);
         if (vuip.nalHRDParams != null) {
             writeHRDParameters(vuip.nalHRDParams, writer);
         }
-        writer.writeBool(vuip.vclHRDParams != null, "VUI: ");
+        writer.writeBool(vuip.vclHRDParams != null, VUI);
         if (vuip.vclHRDParams != null) {
             writeHRDParameters(vuip.vclHRDParams, writer);
         }
@@ -480,7 +483,7 @@ public class SeqParameterSet extends BitstreamElement {
         }
         writer.writeBool(vuip.pic_struct_present_flag,
                 "VUI: pic_struct_present_flag");
-        writer.writeBool(vuip.bitstreamRestriction != null, "VUI: ");
+        writer.writeBool(vuip.bitstreamRestriction != null, VUI);
         if (vuip.bitstreamRestriction != null) {
             writer
                     .writeBool(
@@ -511,9 +514,9 @@ public class SeqParameterSet extends BitstreamElement {
         writer.writeNBit(hrd.cpb_size_scale, 4, "HRD: cpb_size_scale");
 
         for (int SchedSelIdx = 0; SchedSelIdx <= hrd.cpb_cnt_minus1; SchedSelIdx++) {
-            writer.writeUE(hrd.bit_rate_value_minus1[SchedSelIdx], "HRD: ");
-            writer.writeUE(hrd.cpb_size_value_minus1[SchedSelIdx], "HRD: ");
-            writer.writeBool(hrd.cbr_flag[SchedSelIdx], "HRD: ");
+            writer.writeUE(hrd.bit_rate_value_minus1[SchedSelIdx], HRD);
+            writer.writeUE(hrd.cpb_size_value_minus1[SchedSelIdx], HRD);
+            writer.writeBool(hrd.cbr_flag[SchedSelIdx], HRD);
         }
         writer.writeNBit(hrd.initial_cpb_removal_delay_length_minus1, 5,
                 "HRD: initial_cpb_removal_delay_length_minus1");

--- a/muxer/src/main/java/org/mp4parser/muxer/tracks/h265/H265TrackImplOld.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/tracks/h265/H265TrackImplOld.java
@@ -23,6 +23,7 @@ import java.util.List;
  * Created by sannies on 08.09.2014.
  */
 public class H265TrackImplOld {
+    private static final String VPS_MAX_DEC_PIC_BUFFERING_MINUS = "vps_max_dec_pic_buffering_minus1[";
     public static final int VPS_NUT = 32;
     public static final int SPS_NUT = 33;
     public static final int PPS_NUT = 34;
@@ -220,9 +221,9 @@ public class H265TrackImplOld {
         int[] vps_max_num_reorder_pics = new int[vps_sub_layer_ordering_info_present_flag ? 0 : vps_max_sub_layers_minus1];
         int[] vps_max_latency_increase_plus1 = new int[vps_sub_layer_ordering_info_present_flag ? 0 : vps_max_sub_layers_minus1];
         for (int i = (vps_sub_layer_ordering_info_present_flag ? 0 : vps_max_sub_layers_minus1); i <= vps_max_sub_layers_minus1; i++) {
-            vps_max_dec_pic_buffering_minus1[i] = r.readUE("vps_max_dec_pic_buffering_minus1[" + i + "]");
-            vps_max_num_reorder_pics[i] = r.readUE("vps_max_dec_pic_buffering_minus1[" + i + "]");
-            vps_max_latency_increase_plus1[i] = r.readUE("vps_max_dec_pic_buffering_minus1[" + i + "]");
+            vps_max_dec_pic_buffering_minus1[i] = r.readUE(VPS_MAX_DEC_PIC_BUFFERING_MINUS + i + "]");
+            vps_max_num_reorder_pics[i] = r.readUE(VPS_MAX_DEC_PIC_BUFFERING_MINUS + i + "]");
+            vps_max_latency_increase_plus1[i] = r.readUE(VPS_MAX_DEC_PIC_BUFFERING_MINUS + i + "]");
         }
         int vps_max_layer_id = r.readU(6, "vps_max_layer_id");
         int vps_num_layer_sets_minus1 = r.readUE("vps_num_layer_sets_minus1");

--- a/muxer/src/main/java/org/mp4parser/muxer/tracks/h265/VideoParameterSet.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/tracks/h265/VideoParameterSet.java
@@ -8,6 +8,8 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 
 public class VideoParameterSet {
+    private static final String VPS_MAX_DEC_PIC_BUFFERING_MINUS = "vps_max_dec_pic_buffering_minus1[";
+
     ByteBuffer vps;
 
     int vps_parameter_set_id;
@@ -29,9 +31,9 @@ public class VideoParameterSet {
         int[] vps_max_num_reorder_pics = new int[vps_sub_layer_ordering_info_present_flag ? 1 : vps_max_sub_layers_minus1 + 1];
         int[] vps_max_latency_increase_plus1 = new int[vps_sub_layer_ordering_info_present_flag ? 1 : vps_max_sub_layers_minus1 + 1];
         for (int i = (vps_sub_layer_ordering_info_present_flag ? 0 : vps_max_sub_layers_minus1); i <= vps_max_sub_layers_minus1; i++) {
-            vps_max_dec_pic_buffering_minus1[i] = r.readUE("vps_max_dec_pic_buffering_minus1[" + i + "]");
-            vps_max_num_reorder_pics[i] = r.readUE("vps_max_dec_pic_buffering_minus1[" + i + "]");
-            vps_max_latency_increase_plus1[i] = r.readUE("vps_max_dec_pic_buffering_minus1[" + i + "]");
+            vps_max_dec_pic_buffering_minus1[i] = r.readUE(VPS_MAX_DEC_PIC_BUFFERING_MINUS + i + "]");
+            vps_max_num_reorder_pics[i] = r.readUE(VPS_MAX_DEC_PIC_BUFFERING_MINUS + i + "]");
+            vps_max_latency_increase_plus1[i] = r.readUE(VPS_MAX_DEC_PIC_BUFFERING_MINUS + i + "]");
         }
         int vps_max_layer_id = r.readU(6, "vps_max_layer_id");
         int vps_num_layer_sets_minus1 = r.readUE("vps_num_layer_sets_minus1");

--- a/muxer/src/main/java/org/mp4parser/muxer/tracks/ttml/TtmlHelpers.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/tracks/ttml/TtmlHelpers.java
@@ -31,6 +31,7 @@ public class TtmlHelpers {
     public static final String SMPTE_TT_NAMESPACE = "http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt";
     public static final String TTML_NAMESPACE = "http://www.w3.org/ns/ttml";
     public static final NamespaceContext NAMESPACE_CONTEXT = new TextTrackNamespaceContext();
+    private static final String BEGIN = "begin";
     static byte[] namespacesStyleSheet1 = ("<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">\n" +
             "    <xsl:output method=\"text\"/>\n" +
             "    <xsl:key name=\"kElemByNSURI\"\n" +
@@ -156,13 +157,13 @@ public class TtmlHelpers {
         long time = 0;
         Node current = p;
         while ((current = current.getParentNode()) != null) {
-            if (current.getAttributes() != null && current.getAttributes().getNamedItem("begin") != null) {
-                time += toTime(current.getAttributes().getNamedItem("begin").getNodeValue());
+            if (current.getAttributes() != null && current.getAttributes().getNamedItem(BEGIN) != null) {
+                time += toTime(current.getAttributes().getNamedItem(BEGIN).getNodeValue());
             }
         }
 
-        if (p.getAttributes() != null && p.getAttributes().getNamedItem("begin") != null) {
-            return time + toTime(p.getAttributes().getNamedItem("begin").getNodeValue());
+        if (p.getAttributes() != null && p.getAttributes().getNamedItem(BEGIN) != null) {
+            return time + toTime(p.getAttributes().getNamedItem(BEGIN).getNodeValue());
         }
         return time;
     }
@@ -171,8 +172,8 @@ public class TtmlHelpers {
         long time = 0;
         Node current = p;
         while ((current = current.getParentNode()) != null) {
-            if (current.getAttributes() != null && current.getAttributes().getNamedItem("begin") != null) {
-                time += toTime(current.getAttributes().getNamedItem("begin").getNodeValue());
+            if (current.getAttributes() != null && current.getAttributes().getNamedItem(BEGIN) != null) {
+                time += toTime(current.getAttributes().getNamedItem(BEGIN).getNodeValue());
             }
         }
 
@@ -225,18 +226,20 @@ public class TtmlHelpers {
     private static class TextTrackNamespaceContext implements NamespaceContext {
 
 
+        private static final String SMPTE = "smpte";
+
         public String getNamespaceURI(String prefix) {
             if (prefix.equals("ttml")) {
                 return TTML_NAMESPACE;
             }
-            if (prefix.equals("smpte")) {
+            if (prefix.equals(SMPTE)) {
                 return SMPTE_TT_NAMESPACE;
             }
             return null;
         }
 
         public Iterator getPrefixes(String val) {
-            return Arrays.asList("ttml", "smpte").iterator();
+            return Arrays.asList("ttml", SMPTE).iterator();
         }
 
         public String getPrefix(String uri) {
@@ -244,7 +247,7 @@ public class TtmlHelpers {
                 return "ttml";
             }
             if (uri.equals(SMPTE_TT_NAMESPACE)) {
-                return "smpte";
+                return SMPTE;
             }
             return null;
         }

--- a/muxer/src/main/java/org/mp4parser/muxer/tracks/ttml/TtmlSegmenter.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/tracks/ttml/TtmlSegmenter.java
@@ -14,6 +14,8 @@ import static org.mp4parser.muxer.tracks.ttml.TtmlHelpers.*;
 
 public class TtmlSegmenter {
 
+    private static final String BEGIN = "begin";
+
     public static List<Document> split(Document doc, int splitTimeInSeconds) throws XPathExpressionException {
         int splitTime = splitTimeInSeconds * 1000;
         XPathFactory xPathfactory = XPathFactory.newInstance();
@@ -39,7 +41,7 @@ public class TtmlSegmenter {
                 long endTime = getEndTime(p);
                 //p.appendChild(d.createComment(toTimeExpression(startTime) + " -> " + toTimeExpression(endTime)));
                 if (startTime < segmentStartTime && endTime > segmentStartTime) {
-                    changeTime(p, "begin", segmentStartTime - startTime);
+                    changeTime(p, BEGIN, segmentStartTime - startTime);
                     startTime = segmentStartTime;
 
                 }
@@ -58,7 +60,7 @@ public class TtmlSegmenter {
                     Node parent = p.getParentNode();
                     parent.removeChild(p);
                 } else {
-                    changeTime(p, "begin", -segmentStartTime);
+                    changeTime(p, BEGIN, -segmentStartTime);
                     changeTime(p, "end", -segmentStartTime);
                 }
 
@@ -67,12 +69,12 @@ public class TtmlSegmenter {
 
             XPathExpression bodyXP = xpath.compile("/*[name()='tt']/*[name()='body'][1]");
             Element body = (Element) bodyXP.evaluate(d, XPathConstants.NODE);
-            String beginTime = body.getAttribute("begin");
+            String beginTime = body.getAttribute(BEGIN);
             String endTime = body.getAttribute("end");
             if (beginTime == null || "".equals(beginTime)) {
-                body.setAttribute("begin", toTimeExpression(segmentStartTime));
+                body.setAttribute(BEGIN, toTimeExpression(segmentStartTime));
             } else {
-                changeTime(body, "begin", segmentStartTime);
+                changeTime(body, BEGIN, segmentStartTime);
             }
             if (endTime == null || "".equals(endTime)) {
                 body.setAttribute("end", toTimeExpression(segmentEndTime));
@@ -119,7 +121,7 @@ public class TtmlSegmenter {
         }
         for (int i = 0; i < timedNodes.getLength(); i++) {
             Node p = timedNodes.item(i);
-            removeAfterPushDown(p, "begin");
+            removeAfterPushDown(p, BEGIN);
             removeAfterPushDown(p, "end");
 
         }
@@ -131,13 +133,13 @@ public class TtmlSegmenter {
 
         Node current = p;
         while ((current = current.getParentNode()) != null) {
-            if (current.getAttributes() != null && current.getAttributes().getNamedItem("begin") != null) {
-                time += toTime(current.getAttributes().getNamedItem("begin").getNodeValue());
+            if (current.getAttributes() != null && current.getAttributes().getNamedItem(BEGIN) != null) {
+                time += toTime(current.getAttributes().getNamedItem(BEGIN).getNodeValue());
             }
         }
 
-        if (p.getAttributes() != null && p.getAttributes().getNamedItem("begin") != null) {
-            p.getAttributes().getNamedItem("begin").setNodeValue(toTimeExpression(time + toTime(p.getAttributes().getNamedItem("begin").getNodeValue())));
+        if (p.getAttributes() != null && p.getAttributes().getNamedItem(BEGIN) != null) {
+            p.getAttributes().getNamedItem(BEGIN).setNodeValue(toTimeExpression(time + toTime(p.getAttributes().getNamedItem(BEGIN).getNodeValue())));
         }
         if (p.getAttributes() != null && p.getAttributes().getNamedItem("end") != null) {
             p.getAttributes().getNamedItem("end").setNodeValue(toTimeExpression(time + toTime(p.getAttributes().getNamedItem("end").getNodeValue())));


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1192 String literals should not be duplicated.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1192
Please let me know if you have any questions.
George Kankava