### PR TITLE
squid:S00100 - Method names should comply with a naming convention

### DIFF
--- a/muxer/src/main/java/org/mp4parser/muxer/tracks/h264/parsing/model/SeqParameterSet.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/tracks/h264/parsing/model/SeqParameterSet.java
@@ -176,7 +176,7 @@ public class SeqParameterSet extends BitstreamElement {
         boolean vui_parameters_present_flag = reader
                 .readBool("SPS: vui_parameters_present_flag");
         if (vui_parameters_present_flag)
-            sps.vuiParams = ReadVUIParameters(reader);
+            sps.vuiParams = readVUIParameters(reader);
 
         reader.readTrailingBits();
 
@@ -203,7 +203,7 @@ public class SeqParameterSet extends BitstreamElement {
         }
     }
 
-    private static VUIParameters ReadVUIParameters(CAVLCReader reader)
+    private static VUIParameters readVUIParameters(CAVLCReader reader)
             throws IOException {
         VUIParameters vuip = new VUIParameters();
         vuip.aspect_ratio_info_present_flag = reader

--- a/muxer/src/main/java/org/mp4parser/muxer/tracks/h265/H265TrackImplOld.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/tracks/h265/H265TrackImplOld.java
@@ -251,7 +251,7 @@ public class H265TrackImplOld {
                     cprms_present_flag[0] = true;
                 }
 
-                hrd_parameters(cprms_present_flag[i], vps_max_sub_layers_minus1, r);
+                hrdParameters(cprms_present_flag[i], vps_max_sub_layers_minus1, r);
             }
         }
 
@@ -265,7 +265,7 @@ public class H265TrackImplOld {
         return 0;
     }
 
-    private void hrd_parameters(boolean commonInfPresentFlag, int maxNumSubLayersMinus1, CAVLCReader r) throws IOException {
+    private void hrdParameters(boolean commonInfPresentFlag, int maxNumSubLayersMinus1, CAVLCReader r) throws IOException {
         boolean nal_hrd_parameters_present_flag = false;
         boolean vcl_hrd_parameters_present_flag = false;
         boolean sub_pic_hrd_params_present_flag = false;
@@ -310,16 +310,16 @@ public class H265TrackImplOld {
                 cpb_cnt_minus1[i] = r.readUE("cpb_cnt_minus1[" + i + "]");
             }
             if (nal_hrd_parameters_present_flag) {
-                sub_layer_hrd_parameters(i, cpb_cnt_minus1[i], sub_pic_hrd_params_present_flag, r);
+                subLayerHrdParameters(i, cpb_cnt_minus1[i], sub_pic_hrd_params_present_flag, r);
             }
             if (vcl_hrd_parameters_present_flag) {
-                sub_layer_hrd_parameters(i, cpb_cnt_minus1[i], sub_pic_hrd_params_present_flag, r);
+                subLayerHrdParameters(i, cpb_cnt_minus1[i], sub_pic_hrd_params_present_flag, r);
             }
         }
 
     }
 
-    void sub_layer_hrd_parameters(int subLayerId, int cpbCnt, boolean sub_pic_hrd_params_present_flag, CAVLCReader r) throws IOException {
+    void subLayerHrdParameters(int subLayerId, int cpbCnt, boolean sub_pic_hrd_params_present_flag, CAVLCReader r) throws IOException {
         int bit_rate_value_minus1[] = new int[cpbCnt];
         int cpb_size_value_minus1[] = new int[cpbCnt];
         int cpb_size_du_value_minus1[] = new int[cpbCnt];

--- a/muxer/src/main/java/org/mp4parser/muxer/tracks/h265/SequenceParameterSetRbsp.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/tracks/h265/SequenceParameterSetRbsp.java
@@ -15,7 +15,7 @@ public class SequenceParameterSetRbsp {
         int sps_video_parameter_set_id = (int) bsr.readNBit(4, "sps_video_parameter_set_id");
         int sps_max_sub_layers_minus1 = (int) bsr.readNBit(3, "sps_max_sub_layers_minus1");
         boolean sps_temporal_id_nesting_flag = bsr.readBool("sps_temporal_id_nesting_flag");
-        profile_tier_level(sps_max_sub_layers_minus1, bsr);
+        profileTierLevel(sps_max_sub_layers_minus1, bsr);
         int sps_seq_parameter_set_id = bsr.readUE("sps_seq_parameter_set_id");
         int chroma_format_idc = bsr.readUE("chroma_format_idc");
         if (chroma_format_idc == 3) {
@@ -57,7 +57,7 @@ public class SequenceParameterSetRbsp {
         if (scaling_list_enabled_flag) {
             boolean sps_scaling_list_data_present_flag = bsr.readBool("sps_scaling_list_data_present_flag");
             if (sps_scaling_list_data_present_flag) {
-                scaling_list_data(bsr);
+                scalingListData(bsr);
             }
         }
         boolean amp_enabled_flag = bsr.readBool("amp_enabled_flag");
@@ -71,7 +71,7 @@ public class SequenceParameterSetRbsp {
         }
     }
 
-    private void scaling_list_data(CAVLCReader bsr) throws IOException {
+    private void scalingListData(CAVLCReader bsr) throws IOException {
         boolean[][] scaling_list_pred_mode_flag = new boolean[4][];
         int[][] scaling_list_pred_matrix_id_delta = new int[4][];
         int[][] scaling_list_dc_coef_minus8 = new int[2][];
@@ -104,7 +104,7 @@ public class SequenceParameterSetRbsp {
     }
 
 
-    private void profile_tier_level(int maxNumSubLayersMinus1, CAVLCReader bsr) throws IOException {
+    private void profileTierLevel(int maxNumSubLayersMinus1, CAVLCReader bsr) throws IOException {
         int general_profile_space = bsr.readU(2, "general_profile_space");
         boolean general_tier_flag = bsr.readBool("general_tier_flag");
         int general_profile_idc = bsr.readU(5, "general_profile_idc");

--- a/muxer/src/main/java/org/mp4parser/muxer/tracks/h265/VideoParameterSet.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/tracks/h265/VideoParameterSet.java
@@ -60,7 +60,7 @@ public class VideoParameterSet {
                     cprms_present_flag[0] = true;
                 }
 
-                hrd_parameters(cprms_present_flag[i], vps_max_sub_layers_minus1, r);
+                hrdParameters(cprms_present_flag[i], vps_max_sub_layers_minus1, r);
             }
         }
 
@@ -133,7 +133,7 @@ public class VideoParameterSet {
         }
     }
 
-    private void hrd_parameters(boolean commonInfPresentFlag, int maxNumSubLayersMinus1, CAVLCReader r) throws IOException {
+    private void hrdParameters(boolean commonInfPresentFlag, int maxNumSubLayersMinus1, CAVLCReader r) throws IOException {
         boolean nal_hrd_parameters_present_flag = false;
         boolean vcl_hrd_parameters_present_flag = false;
         boolean sub_pic_hrd_params_present_flag = false;
@@ -178,16 +178,16 @@ public class VideoParameterSet {
                 cpb_cnt_minus1[i] = r.readUE("cpb_cnt_minus1[" + i + "]");
             }
             if (nal_hrd_parameters_present_flag) {
-                sub_layer_hrd_parameters(i, cpb_cnt_minus1[i], sub_pic_hrd_params_present_flag, r);
+                subLayerHrdParameters(i, cpb_cnt_minus1[i], sub_pic_hrd_params_present_flag, r);
             }
             if (vcl_hrd_parameters_present_flag) {
-                sub_layer_hrd_parameters(i, cpb_cnt_minus1[i], sub_pic_hrd_params_present_flag, r);
+                subLayerHrdParameters(i, cpb_cnt_minus1[i], sub_pic_hrd_params_present_flag, r);
             }
         }
 
     }
 
-    void sub_layer_hrd_parameters(int subLayerId, int cpbCnt, boolean sub_pic_hrd_params_present_flag, CAVLCReader r) throws IOException {
+    void subLayerHrdParameters(int subLayerId, int cpbCnt, boolean sub_pic_hrd_params_present_flag, CAVLCReader r) throws IOException {
         int bit_rate_value_minus1[] = new int[cpbCnt];
         int cpb_size_value_minus1[] = new int[cpbCnt];
         int cpb_size_du_value_minus1[] = new int[cpbCnt];


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S00100 Method names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00100
Please let me know if you have any questions.
George Kankava