### PR TITLE
squid:S1444 public static fields should be constant

### DIFF
--- a/muxer/src/main/java/org/mp4parser/muxer/tracks/AACTrackImpl.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/tracks/AACTrackImpl.java
@@ -36,7 +36,7 @@ import java.util.*;
  */
 public class AACTrackImpl extends AbstractTrack {
 
-    public static Map<Integer, Integer> samplingFrequencyIndexMap = new HashMap<Integer, Integer>();
+    public static final Map<Integer, Integer> SAMPLING_FREQUENCY_INDEX_MAP = new HashMap<Integer, Integer>();
     static Map<Integer, String> audioObjectTypes = new HashMap<Integer, String>();
 
     static {
@@ -88,30 +88,30 @@ public class AACTrackImpl extends AbstractTrack {
     }
 
     static {
-        samplingFrequencyIndexMap.put(96000, 0);
-        samplingFrequencyIndexMap.put(88200, 1);
-        samplingFrequencyIndexMap.put(64000, 2);
-        samplingFrequencyIndexMap.put(48000, 3);
-        samplingFrequencyIndexMap.put(44100, 4);
-        samplingFrequencyIndexMap.put(32000, 5);
-        samplingFrequencyIndexMap.put(24000, 6);
-        samplingFrequencyIndexMap.put(22050, 7);
-        samplingFrequencyIndexMap.put(16000, 8);
-        samplingFrequencyIndexMap.put(12000, 9);
-        samplingFrequencyIndexMap.put(11025, 10);
-        samplingFrequencyIndexMap.put(8000, 11);
-        samplingFrequencyIndexMap.put(0x0, 96000);
-        samplingFrequencyIndexMap.put(0x1, 88200);
-        samplingFrequencyIndexMap.put(0x2, 64000);
-        samplingFrequencyIndexMap.put(0x3, 48000);
-        samplingFrequencyIndexMap.put(0x4, 44100);
-        samplingFrequencyIndexMap.put(0x5, 32000);
-        samplingFrequencyIndexMap.put(0x6, 24000);
-        samplingFrequencyIndexMap.put(0x7, 22050);
-        samplingFrequencyIndexMap.put(0x8, 16000);
-        samplingFrequencyIndexMap.put(0x9, 12000);
-        samplingFrequencyIndexMap.put(0xa, 11025);
-        samplingFrequencyIndexMap.put(0xb, 8000);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(96000, 0);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(88200, 1);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(64000, 2);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(48000, 3);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(44100, 4);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(32000, 5);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(24000, 6);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(22050, 7);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(16000, 8);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(12000, 9);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(11025, 10);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(8000, 11);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(0x0, 96000);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(0x1, 88200);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(0x2, 64000);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(0x3, 48000);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(0x4, 44100);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(0x5, 32000);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(0x6, 24000);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(0x7, 22050);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(0x8, 16000);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(0x9, 12000);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(0xa, 11025);
+        SAMPLING_FREQUENCY_INDEX_MAP.put(0xb, 8000);
     }
 
     TrackMetaData trackMetaData = new TrackMetaData();
@@ -273,7 +273,7 @@ public class AACTrackImpl extends AbstractTrack {
         hdr.profile = brb.readBits(2) + 1;  // E
         //System.err.println(String.format("Profile %s", audioObjectTypes.get(hdr.profile)));
         hdr.sampleFrequencyIndex = brb.readBits(4);
-        hdr.sampleRate = samplingFrequencyIndexMap.get(hdr.sampleFrequencyIndex); // F
+        hdr.sampleRate = SAMPLING_FREQUENCY_INDEX_MAP.get(hdr.sampleFrequencyIndex); // F
         brb.readBits(1); // G
         hdr.channelconfig = brb.readBits(3); // H
         hdr.original = brb.readBits(1); // I

--- a/muxer/src/main/java/org/mp4parser/muxer/tracks/AbstractH26XTrack.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/tracks/AbstractH26XTrack.java
@@ -17,7 +17,7 @@ import java.util.List;
  */
 public abstract class AbstractH26XTrack extends AbstractTrack {
 
-    public static int BUFFER = 65535 << 10;
+    public static final int BUFFER = 65535 << 10;
     protected long[] decodingTimes;
     protected List<CompositionTimeToSample.Entry> ctts = new ArrayList<CompositionTimeToSample.Entry>();
     protected List<SampleDependencyTypeBox.Entry> sdtp = new ArrayList<SampleDependencyTypeBox.Entry>();

--- a/muxer/src/main/java/org/mp4parser/muxer/tracks/h264/parsing/model/ChromaFormat.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/tracks/h264/parsing/model/ChromaFormat.java
@@ -26,10 +26,10 @@ package org.mp4parser.muxer.tracks.h264.parsing.model;
  * @author Stanislav Vitvitskiy
  */
 public class ChromaFormat {
-    public static ChromaFormat MONOCHROME = new ChromaFormat(0, 0, 0);
-    public static ChromaFormat YUV_420 = new ChromaFormat(1, 2, 2);
-    public static ChromaFormat YUV_422 = new ChromaFormat(2, 2, 1);
-    public static ChromaFormat YUV_444 = new ChromaFormat(3, 1, 1);
+    public static final ChromaFormat MONOCHROME = new ChromaFormat(0, 0, 0);
+    public static final ChromaFormat YUV_420 = new ChromaFormat(1, 2, 2);
+    public static final ChromaFormat YUV_422 = new ChromaFormat(2, 2, 1);
+    public static final ChromaFormat YUV_444 = new ChromaFormat(3, 1, 1);
 
     private int id;
     private int subWidth;


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1444 public static fields should be constant.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1444
Please let me know if you have any questions.
George Kankava