### PR TITLE
squid:LowerCaseLongSuffixCheck Long suffix L should be upper case

### DIFF
--- a/isoparser/src/main/java/org/mp4parser/boxes/iso14496/part12/MovieHeaderBox.java
+++ b/isoparser/src/main/java/org/mp4parser/boxes/iso14496/part12/MovieHeaderBox.java
@@ -65,7 +65,7 @@ public class MovieHeaderBox extends AbstractFullBox {
 
     public void setCreationTime(Date creationTime) {
         this.creationTime = creationTime;
-        if (DateHelper.convert(creationTime) >= (1l << 32)) {
+        if (DateHelper.convert(creationTime) >= (1L << 32)) {
             setVersion(1);
         }
 
@@ -77,7 +77,7 @@ public class MovieHeaderBox extends AbstractFullBox {
 
     public void setModificationTime(Date modificationTime) {
         this.modificationTime = modificationTime;
-        if (DateHelper.convert(modificationTime) >= (1l << 32)) {
+        if (DateHelper.convert(modificationTime) >= (1L << 32)) {
             setVersion(1);
         }
 
@@ -97,7 +97,7 @@ public class MovieHeaderBox extends AbstractFullBox {
 
     public void setDuration(long duration) {
         this.duration = duration;
-        if (duration >= (1l << 32)) {
+        if (duration >= (1L << 32)) {
             setVersion(1);
         }
     }

--- a/isoparser/src/main/java/org/mp4parser/boxes/iso14496/part12/TrackHeaderBox.java
+++ b/isoparser/src/main/java/org/mp4parser/boxes/iso14496/part12/TrackHeaderBox.java
@@ -63,7 +63,7 @@ public class TrackHeaderBox extends AbstractFullBox {
 
     public void setCreationTime(Date creationTime) {
         this.creationTime = creationTime;
-        if (DateHelper.convert(creationTime) >= (1l << 32)) {
+        if (DateHelper.convert(creationTime) >= (1L << 32)) {
             setVersion(1);
         }
     }
@@ -74,7 +74,7 @@ public class TrackHeaderBox extends AbstractFullBox {
 
     public void setModificationTime(Date modificationTime) {
         this.modificationTime = modificationTime;
-        if (DateHelper.convert(modificationTime) >= (1l << 32)) {
+        if (DateHelper.convert(modificationTime) >= (1L << 32)) {
             setVersion(1);
         }
 
@@ -94,7 +94,7 @@ public class TrackHeaderBox extends AbstractFullBox {
 
     public void setDuration(long duration) {
         this.duration = duration;
-        if (duration >= (1l << 32)) {
+        if (duration >= (1L << 32)) {
             setFlags(1);
         }
     }

--- a/isoparser/src/main/java/org/mp4parser/boxes/iso14496/part15/HevcDecoderConfigurationRecord.java
+++ b/isoparser/src/main/java/org/mp4parser/boxes/iso14496/part15/HevcDecoderConfigurationRecord.java
@@ -149,16 +149,16 @@ public class HevcDecoderConfigurationRecord {
         IsoTypeWriter.writeUInt32(byteBuffer, general_profile_compatibility_flags);
         long _general_constraint_indicator_flags = general_constraint_indicator_flags;
         if (frame_only_constraint_flag) {
-            _general_constraint_indicator_flags |= 1l << 47;
+            _general_constraint_indicator_flags |= 1L << 47;
         }
         if (non_packed_constraint_flag) {
-            _general_constraint_indicator_flags |= 1l << 46;
+            _general_constraint_indicator_flags |= 1L << 46;
         }
         if (interlaced_source_flag) {
-            _general_constraint_indicator_flags |= 1l << 45;
+            _general_constraint_indicator_flags |= 1L << 45;
         }
         if (progressive_source_flag) {
-            _general_constraint_indicator_flags |= 1l << 44;
+            _general_constraint_indicator_flags |= 1L << 44;
         }
 
         IsoTypeWriter.writeUInt48(byteBuffer, _general_constraint_indicator_flags);

--- a/isoparser/src/main/java/org/mp4parser/boxes/iso23001/part7/AbstractSampleEncryptionBox.java
+++ b/isoparser/src/main/java/org/mp4parser/boxes/iso23001/part7/AbstractSampleEncryptionBox.java
@@ -26,7 +26,7 @@ public abstract class AbstractSampleEncryptionBox extends AbstractFullBox {
     }
 
     public int getOffsetToFirstIV() {
-        int offset = (getSize() > (1l << 32) ? 16 : 8);
+        int offset = (getSize() > (1L << 32) ? 16 : 8);
         offset += isOverrideTrackEncryptionBoxParameters() ? (4 + kid.length) : 0;
         offset += 4; //num entries
         return offset;

--- a/isoparser/src/main/java/org/mp4parser/tools/IsoTypeReader.java
+++ b/isoparser/src/main/java/org/mp4parser/tools/IsoTypeReader.java
@@ -35,7 +35,7 @@ public final class IsoTypeReader {
     public static long readUInt32(ByteBuffer bb) {
         long i = bb.getInt();
         if (i < 0) {
-            i += 1l << 32;
+            i += 1L << 32;
         }
         return i;
     }

--- a/isoparser/src/main/java/org/mp4parser/tools/IsoTypeWriter.java
+++ b/isoparser/src/main/java/org/mp4parser/tools/IsoTypeWriter.java
@@ -46,9 +46,9 @@ public final class IsoTypeWriter {
     }
 
     public static void writeUInt48(ByteBuffer bb, long l) {
-        l = l & 0xFFFFFFFFFFFFl;
+        l = l & 0xFFFFFFFFFFFFL;
         writeUInt16(bb, (int) (l >> 32));
-        writeUInt32(bb, l & 0xFFFFFFFFl);
+        writeUInt32(bb, l & 0xFFFFFFFFL);
 
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:LowerCaseLongSuffixCheck Long suffix L should be upper case.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3ALowerCaseLongSuffixCheck
Please let me know if you have any questions.
George Kankava