### PR TITLE
multiple code improvements: squid:S1155, squid:S1905, squid:S1153

### DIFF
--- a/examples/src/main/java/com/ChopSuey.java
+++ b/examples/src/main/java/com/ChopSuey.java
@@ -74,7 +74,7 @@ public class ChopSuey {
                 index++;
 
             }
-            if (chops.size() > 0) {
+            if (!chops.isEmpty()) {
                 tracks.put(track, chops);
             }
 

--- a/examples/src/main/java/com/googlecode/mp4parser/AppendExample.java
+++ b/examples/src/main/java/com/googlecode/mp4parser/AppendExample.java
@@ -132,10 +132,10 @@ public class AppendExample {
 
         Movie result = new Movie();
 
-        if (audioTracks.size() > 0) {
+        if (!audioTracks.isEmpty()) {
             result.addTrack(new AppendTrack(audioTracks.toArray(new Track[audioTracks.size()])));
         }
-        if (videoTracks.size() > 0) {
+        if (!videoTracks.isEmpty()) {
             result.addTrack(new AppendTrack(videoTracks.toArray(new Track[videoTracks.size()])));
         }
 

--- a/examples/src/main/java/org/mp4parser/examples/metadata/MetaDataInsert.java
+++ b/examples/src/main/java/org/mp4parser/examples/metadata/MetaDataInsert.java
@@ -176,7 +176,7 @@ public class MetaDataInsert {
 
     private void correctChunkOffsets(MovieBox movieBox, long correction) {
         List<ChunkOffsetBox> chunkOffsetBoxes = Path.getPaths((Box) movieBox, "trak/mdia[0]/minf[0]/stbl[0]/stco[0]");
-        if (chunkOffsetBoxes.size() == 0) {
+        if (chunkOffsetBoxes.isEmpty()) {
             chunkOffsetBoxes = Path.getPaths((Box) movieBox, "trak/mdia[0]/minf[0]/stbl[0]/st64[0]");
         }
         for (ChunkOffsetBox chunkOffsetBox : chunkOffsetBoxes) {

--- a/isoparser/src/main/java/org/mp4parser/boxes/iso14496/part12/SampleSizeBox.java
+++ b/isoparser/src/main/java/org/mp4parser/boxes/iso14496/part12/SampleSizeBox.java
@@ -91,7 +91,7 @@ public class SampleSizeBox extends AbstractFullBox {
         sampleCount = CastUtils.l2i(IsoTypeReader.readUInt32(content));
 
         if (sampleSize == 0) {
-            sampleSizes = new long[(int) sampleCount];
+            sampleSizes = new long[sampleCount];
 
             for (int i = 0; i < sampleCount; i++) {
                 sampleSizes[i] = IsoTypeReader.readUInt32(content);

--- a/isoparser/src/main/java/org/mp4parser/boxes/microsoft/XtraBox.java
+++ b/isoparser/src/main/java/org/mp4parser/boxes/microsoft/XtraBox.java
@@ -530,7 +530,7 @@ public class XtraBox extends AbstractBox {
                 case MP4_XTRA_BT_UNICODE:
                     return "[string]" + stringValue;
                 case MP4_XTRA_BT_INT64:
-                    return "[long]" + String.valueOf(longValue);
+                    return "[long]" + longValue;
                 case MP4_XTRA_BT_FILETIME:
                     return "[filetime]" + fileTimeValue.toString();
                 case MP4_XTRA_BT_GUID:


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1155 Collection.isEmpty() should be used to test for emptiness,
squid:S1905 Redundant casts should not be used,
squid:S1153 String.valueOf() should not be appended to a String.
You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1155
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1905
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1153
Please let me know if you have any questions.
George Kankava