### PR TITLE
squid:S2325 private methods that dont access instance data should be static

### DIFF
--- a/isoparser/src/main/java/org/mp4parser/boxes/iso14496/part1/objectdescriptors/AudioSpecificConfig.java
+++ b/isoparser/src/main/java/org/mp4parser/boxes/iso14496/part1/objectdescriptors/AudioSpecificConfig.java
@@ -993,7 +993,7 @@ public class AudioSpecificConfig extends BaseDescriptor {
         return (ByteBuffer) out.rewind();
     }
 
-    private void writeAudioObjectType(int audioObjectType, BitWriterBuffer bitWriterBuffer) {
+    private static void writeAudioObjectType(int audioObjectType, BitWriterBuffer bitWriterBuffer) {
         if (audioObjectType >= 32) {
             bitWriterBuffer.writeBits(31, 5);
             bitWriterBuffer.writeBits(audioObjectType - 32, 6);
@@ -1002,7 +1002,7 @@ public class AudioSpecificConfig extends BaseDescriptor {
         }
     }
 
-    private int getAudioObjectType(BitReaderBuffer in) throws IOException {
+    private static int getAudioObjectType(BitReaderBuffer in) throws IOException {
         int audioObjectType = in.readBits(5);
         if (audioObjectType == 31) {
             audioObjectType = 32 + in.readBits(6);

--- a/isoparser/src/main/java/org/mp4parser/boxes/samplegrouping/SampleGroupDescriptionBox.java
+++ b/isoparser/src/main/java/org/mp4parser/boxes/samplegrouping/SampleGroupDescriptionBox.java
@@ -122,7 +122,7 @@ public class SampleGroupDescriptionBox extends AbstractFullBox {
 
     }
 
-    private GroupEntry parseGroupEntry(ByteBuffer content, String groupingType) {
+    private static GroupEntry parseGroupEntry(ByteBuffer content, String groupingType) {
         GroupEntry groupEntry;
         if (RollRecoveryEntry.TYPE.equals(groupingType)) {
             groupEntry = new RollRecoveryEntry();

--- a/muxer/src/main/java/org/mp4parser/muxer/tracks/h264/parsing/model/SeqParameterSet.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/tracks/h264/parsing/model/SeqParameterSet.java
@@ -412,7 +412,7 @@ public class SeqParameterSet extends BitstreamElement {
         writer.writeTrailingBits();
     }
 
-    private void writeVUIParameters(VUIParameters vuip, CAVLCWriter writer)
+    private static void writeVUIParameters(VUIParameters vuip, CAVLCWriter writer)
             throws IOException {
         writer.writeBool(vuip.aspect_ratio_info_present_flag,
                 "VUI: aspect_ratio_info_present_flag");

--- a/streaming/src/main/java/org/mp4parser/streaming/input/aac/AdtsAacStreamingTrack.java
+++ b/streaming/src/main/java/org/mp4parser/streaming/input/aac/AdtsAacStreamingTrack.java
@@ -159,7 +159,7 @@ public class AdtsAacStreamingTrack extends AbstractStreamingTrack implements Cal
     }
 
 
-    private AdtsHeader readADTSHeader(InputStream fis) throws IOException {
+    private static AdtsHeader readADTSHeader(InputStream fis) throws IOException {
         AdtsHeader hdr = new AdtsHeader();
         int x = fis.read(); // A
         int syncword = x << 4;


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S2325 private methods that dont access instance data should be static.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2325
Please let me know if you have any questions.
George Kankava