### PR TITLE
multiple code improvements: squid:S2293, squid:S2184, squid:CommentedOutCodeLine, squid:S1854

### DIFF
--- a/muxer/src/main/java/org/mp4parser/muxer/tracks/ttml/TtmlSegmenter.java
+++ b/muxer/src/main/java/org/mp4parser/muxer/tracks/ttml/TtmlSegmenter.java
@@ -23,12 +23,12 @@ public class TtmlSegmenter {
 
         boolean thereIsMore;
 
-        List<Document> subDocs = new ArrayList<Document>();
+        List<Document> subDocs = new ArrayList<>();
 
 
         do {
-            long segmentStartTime = subDocs.size() * splitTime;
-            long segmentEndTime = (subDocs.size() + 1) * splitTime;
+            long segmentStartTime = (long)subDocs.size() * splitTime;
+            long segmentEndTime = (subDocs.size() + 1L) * splitTime;
             Document d = (Document) doc.cloneNode(true);
             NodeList timedNodes = (NodeList) xp.evaluate(d, XPathConstants.NODESET);
             thereIsMore = false;
@@ -37,7 +37,6 @@ public class TtmlSegmenter {
                 Node p = timedNodes.item(i);
                 long startTime = getStartTime(p);
                 long endTime = getEndTime(p);
-                //p.appendChild(d.createComment(toTimeExpression(startTime) + " -> " + toTimeExpression(endTime)));
                 if (startTime < segmentStartTime && endTime > segmentStartTime) {
                     changeTime(p, "begin", segmentStartTime - startTime);
                     startTime = segmentStartTime;
@@ -89,7 +88,7 @@ public class TtmlSegmenter {
         if (p.getAttributes() != null && p.getAttributes().getNamedItem(attribute) != null) {
             String oldValue = p.getAttributes().getNamedItem(attribute).getNodeValue();
             long nuTime = toTime(oldValue) + amount;
-            int frames = 0;
+            int frames;
             if (oldValue.contains(".")) {
                 frames = -1;
             } else {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2293 - The diamond operator ("<>") should be used.
squid:S2184 - Math operands should be cast before assignment.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S1854 - Dead stores should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
https://dev.eclipse.org/sonar/rules/show/squid:S2184
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S1854
Please let me know if you have any questions.
George Kankava
