### PR TITLE
Issue #254 Optional list of boxes to skip when reading file

### DIFF
--- a/isoparser/src/main/java/org/mp4parser/AbstractBoxParser.java
+++ b/isoparser/src/main/java/org/mp4parser/AbstractBoxParser.java
@@ -101,11 +101,11 @@ public abstract class AbstractBoxParser implements BoxParser {
         }
         ParsableBox parsableBox = null;
         if( skippedTypes != null && skippedTypes.contains(type) ) {
-            LOG.info("Skipping box {} {} {}", type, usertype, parentType);
+            LOG.trace("Skipping box {} {} {}", type, usertype, parentType);
             parsableBox = new SkipBox(type, usertype, parentType);
         }
         else {
-            LOG.info("Creating box {} {} {}", type, usertype, parentType);
+            LOG.trace("Creating box {} {} {}", type, usertype, parentType);
             parsableBox = createBox(type, usertype, parentType);
         }
         //LOG.finest("Parsing " + box.getType());

--- a/isoparser/src/main/java/org/mp4parser/AbstractBoxParser.java
+++ b/isoparser/src/main/java/org/mp4parser/AbstractBoxParser.java
@@ -24,12 +24,16 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * This BoxParser handles the basic stuff like reading size and extracting box type.
  */
 public abstract class AbstractBoxParser implements BoxParser {
 
+    private List<String> skippedTypes;
+    
     private static Logger LOG = LoggerFactory.getLogger(AbstractBoxParser.class.getName());
     ThreadLocal<ByteBuffer> header = new ThreadLocal<ByteBuffer>() {
         @Override
@@ -95,8 +99,15 @@ public abstract class AbstractBoxParser implements BoxParser {
             }
             contentSize -= 16;
         }
-        LOG.trace("Creating box {} {}", type, usertype);
-        ParsableBox parsableBox = createBox(type, usertype, parentType);
+        ParsableBox parsableBox = null;
+        if( skippedTypes != null && skippedTypes.contains(type) ) {
+            LOG.info("Skipping box {} {} {}", type, usertype, parentType);
+            parsableBox = new SkipBox(type, usertype, parentType);
+        }
+        else {
+            LOG.info("Creating box {} {} {}", type, usertype, parentType);
+            parsableBox = createBox(type, usertype, parentType);
+        }
         //LOG.finest("Parsing " + box.getType());
         // System.out.println("parsing " + Mp4Arrays.toString(box.getType()) + " " + box.getClass().getName() + " size=" + size);
         header.get().rewind();
@@ -105,5 +116,8 @@ public abstract class AbstractBoxParser implements BoxParser {
         return parsableBox;
     }
 
-
+    public AbstractBoxParser skippingBoxes(String... types) {
+        skippedTypes = Arrays.asList(types);
+        return this;
+    }
 }

--- a/isoparser/src/main/java/org/mp4parser/SkipBox.java
+++ b/isoparser/src/main/java/org/mp4parser/SkipBox.java
@@ -1,0 +1,58 @@
+package org.mp4parser;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+public class SkipBox implements ParsableBox {
+
+    private String type;
+    private long size;
+    private long sourcePosition = -1;
+    
+    public SkipBox(String type, byte[] usertype, String parentType) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public long getContentSize() {
+        return size-8;
+    }
+    
+    /**
+     * Get the seekable position of the content for this box within the source data.
+     * @return The data offset, or -1 if it is not known
+     */
+    public long getSourcePosition() {
+        return sourcePosition;
+    }
+    
+    public void getBox(WritableByteChannel writableByteChannel) throws IOException {
+        throw new RuntimeException("Cannot retrieve a skipped box - type "+type);
+    }
+
+    public void parse(ReadableByteChannel dataSource, ByteBuffer header, long contentSize, BoxParser boxParser)
+            throws IOException {
+        this.size = contentSize+8;
+        
+        if( dataSource instanceof SeekableByteChannel ) {
+            SeekableByteChannel seekable = (SeekableByteChannel) dataSource;
+            sourcePosition = seekable.position();
+            long newPosition = sourcePosition + contentSize;
+            seekable.position(newPosition);
+        }
+        else {
+            throw new RuntimeException("Cannot skip box "+type+" if data source is not seekable");
+        }
+    }
+
+}

--- a/isoparser/src/main/java/org/mp4parser/SkipBox.java
+++ b/isoparser/src/main/java/org/mp4parser/SkipBox.java
@@ -2,8 +2,8 @@ package org.mp4parser;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
-import java.nio.channels.SeekableByteChannel;
 import java.nio.channels.WritableByteChannel;
 
 public class SkipBox implements ParsableBox {
@@ -44,8 +44,8 @@ public class SkipBox implements ParsableBox {
             throws IOException {
         this.size = contentSize+8;
         
-        if( dataSource instanceof SeekableByteChannel ) {
-            SeekableByteChannel seekable = (SeekableByteChannel) dataSource;
+        if( dataSource instanceof FileChannel ) {
+            FileChannel seekable = (FileChannel) dataSource;
             sourcePosition = seekable.position();
             long newPosition = sourcePosition + contentSize;
             seekable.position(newPosition);

--- a/isoparser/src/test/java/org/mp4parser/SkippingBoxTest.java
+++ b/isoparser/src/test/java/org/mp4parser/SkippingBoxTest.java
@@ -1,0 +1,57 @@
+package org.mp4parser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mp4parser.boxes.iso14496.part12.MovieBox;
+import org.mp4parser.boxes.iso14496.part12.TrackHeaderBox;
+import org.mp4parser.tools.Path;
+import org.mp4parser.tools.PathTest;
+
+public class SkippingBoxTest {
+    
+    private IsoFile isoFile;
+    
+    @Before
+    public void setup() throws IOException {
+        FileInputStream fis = new FileInputStream(PathTest.class.getProtectionDomain().getCodeSource().getLocation().getFile() + "/test.m4p");
+        isoFile = new IsoFile(fis.getChannel(), new PropertyBoxParserImpl().skippingBoxes("mdat", "mvhd"));
+        fis.close();
+    }
+
+
+    @Test
+    public void testBoxes() {
+        for(Box box: isoFile.getBoxes()) {
+            System.out.println("Box "+box.getSize()+" -> "+box);
+        }
+        MovieBox movieBox = isoFile.getMovieBox();
+        assertNotNull(movieBox);
+        assertEquals(4, movieBox.getBoxes().size());
+        assertEquals("mvhd", movieBox.getBoxes().get(0).getType());
+        assertEquals("iods", movieBox.getBoxes().get(1).getType());
+        assertEquals("trak", movieBox.getBoxes().get(2).getType());
+        assertEquals("udta", movieBox.getBoxes().get(3).getType());
+        
+        Box box = Path.getPath(isoFile, "moov/trak/tkhd");
+        assertTrue( box instanceof TrackHeaderBox );
+        
+        TrackHeaderBox thb = (TrackHeaderBox)box;
+        assertTrue(thb.getDuration() == 102595);
+        
+        box = Path.getPath(isoFile, "mdat");
+        assertTrue(box instanceof SkipBox);
+        
+        box = Path.getPath(isoFile, "moov/mvhd");
+        assertTrue(box instanceof SkipBox);
+        
+
+    }
+
+}

--- a/isoparser/src/test/java/org/mp4parser/SkippingBoxTest.java
+++ b/isoparser/src/test/java/org/mp4parser/SkippingBoxTest.java
@@ -27,10 +27,7 @@ public class SkippingBoxTest {
 
 
     @Test
-    public void testBoxes() {
-        for(Box box: isoFile.getBoxes()) {
-            System.out.println("Box "+box.getSize()+" -> "+box);
-        }
+    public void testBoxesHaveBeenSkipped() {
         MovieBox movieBox = isoFile.getMovieBox();
         assertNotNull(movieBox);
         assertEquals(4, movieBox.getBoxes().size());
@@ -50,8 +47,6 @@ public class SkippingBoxTest {
         
         box = Path.getPath(isoFile, "moov/mvhd");
         assertTrue(box instanceof SkipBox);
-        
-
     }
 
 }


### PR DESCRIPTION
Add a new method on AbstractBoxParser that allows a list of box types to be skipped (ie. not read) when parsing the source file. This allows metadata to be read without consuming the entire file.

Skipped boxes are replaced by the 'SkipBox' type, which stores the original box type, the length and the offset within the source file for the data that has not been read.

This implementation does not support writing skipped boxes out again. The data source type must be seekable - for instance, a FileChannel.