### PR TITLE
#355 Fix for cbcs encrypted mp4 crashing parsing of senc box.

### DIFF
--- a/isoparser/src/main/java/org/mp4parser/boxes/iso23001/part7/AbstractSampleEncryptionBox.java
+++ b/isoparser/src/main/java/org/mp4parser/boxes/iso23001/part7/AbstractSampleEncryptionBox.java
@@ -46,18 +46,27 @@ public abstract class AbstractSampleEncryptionBox extends AbstractFullBox {
         long numOfEntries = IsoTypeReader.readUInt32(content);
         ByteBuffer parseEight = content.duplicate();
         ByteBuffer parseSixteen = content.duplicate();
+        ByteBuffer parseZero = content.duplicate();
 
         entries = parseEntries(parseEight, numOfEntries, 8);
-        if (entries == null) {
-            entries = parseEntries(parseSixteen, numOfEntries, 16);
-            content.position(content.position() + content.remaining() - parseSixteen.remaining());
-        } else {
+        if (entries != null) {
             content.position(content.position() + content.remaining() - parseEight.remaining());
-        }
-        if (entries == null) {
-            throw new RuntimeException("Cannot parse SampleEncryptionBox");
+            return;
         }
 
+        entries = parseEntries(parseSixteen, numOfEntries, 16);
+        if (entries != null) {
+            content.position(content.position() + content.remaining() - parseSixteen.remaining());
+            return;
+        }
+
+        entries = parseEntries(parseZero, numOfEntries, 0);
+        if (entries != null) {
+            content.position(content.position() + content.remaining() - parseZero.remaining());
+            return;
+        }
+
+        throw new RuntimeException("Cannot parse SampleEncryptionBox");
     }
 
     private List<CencSampleAuxiliaryDataFormat> parseEntries(ByteBuffer content, final long numOfEntries, int ivSize) {
@@ -83,7 +92,6 @@ public abstract class AbstractSampleEncryptionBox extends AbstractFullBox {
             return null;
         }
         return _entries;
-
     }
 
     public List<CencSampleAuxiliaryDataFormat> getEntries() {


### PR DESCRIPTION
Besides assuming 8 and 16 byte iv. 0 is also a valid assumption.