### PR TITLE
Fix some file descriptor / tmp file leaks

### DIFF
--- a/isoparser/src/main/java/org/mp4parser/BasicContainer.java
+++ b/isoparser/src/main/java/org/mp4parser/BasicContainer.java
@@ -1,6 +1,5 @@
 package org.mp4parser;
 
-import java.io.Closeable;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
@@ -9,7 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class BasicContainer implements Container, Closeable {
+public class BasicContainer implements Container {
     private List<Box> boxes = new ArrayList<Box>();
 
     public BasicContainer() {
@@ -114,15 +113,6 @@ public class BasicContainer implements Container, Closeable {
                 } else {
                     throw e;
                 }
-            }
-        }
-    }
-
-    @Override
-    public void close() throws IOException {
-        for (Box box : boxes) {
-            if (box instanceof Closeable) {
-                ((Closeable) box).close();
             }
         }
     }

--- a/isoparser/src/main/java/org/mp4parser/BasicContainer.java
+++ b/isoparser/src/main/java/org/mp4parser/BasicContainer.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class BasicContainer implements Container {
+public class BasicContainer implements Container, Closeable {
     private List<Box> boxes = new ArrayList<Box>();
 
     public BasicContainer() {

--- a/isoparser/src/main/java/org/mp4parser/BasicContainer.java
+++ b/isoparser/src/main/java/org/mp4parser/BasicContainer.java
@@ -1,5 +1,6 @@
 package org.mp4parser;
 
+import java.io.Closeable;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
@@ -117,7 +118,16 @@ public class BasicContainer implements Container {
         }
     }
 
+    @Override
+    public void close() throws IOException {
+        for (Box box : boxes) {
+            if (box instanceof Closeable) {
+                ((Closeable) box).close();
+            }
+        }
+    }
 
+    @Override
     public String toString() {
         StringBuilder buffer = new StringBuilder();
 
@@ -126,7 +136,7 @@ public class BasicContainer implements Container {
             if (i > 0) {
                 buffer.append(";");
             }
-            buffer.append(boxes.get(i).toString());
+            buffer.append(boxes.get(i));
         }
         buffer.append("]");
         return buffer.toString();

--- a/isoparser/src/main/java/org/mp4parser/Container.java
+++ b/isoparser/src/main/java/org/mp4parser/Container.java
@@ -1,5 +1,6 @@
 package org.mp4parser;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
 import java.util.List;
@@ -7,7 +8,7 @@ import java.util.List;
 /**
  * Interface for all ISO boxes that may contain other boxes.
  */
-public interface Container {
+public interface Container extends Closeable {
 
     /**
      * Gets all child boxes. May not return <code>null</code>.

--- a/isoparser/src/main/java/org/mp4parser/Container.java
+++ b/isoparser/src/main/java/org/mp4parser/Container.java
@@ -1,6 +1,5 @@
 package org.mp4parser;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
 import java.util.List;
@@ -8,7 +7,7 @@ import java.util.List;
 /**
  * Interface for all ISO boxes that may contain other boxes.
  */
-public interface Container extends Closeable {
+public interface Container {
 
     /**
      * Gets all child boxes. May not return <code>null</code>.

--- a/isoparser/src/main/java/org/mp4parser/IsoFile.java
+++ b/isoparser/src/main/java/org/mp4parser/IsoFile.java
@@ -29,7 +29,7 @@ import java.nio.charset.StandardCharsets;
  * Uses IsoBufferWrapper  to access the underlying file.
  */
 @DoNotParseDetail
-public class IsoFile extends BasicContainer implements Closeable {
+public class IsoFile extends BasicContainer {
     private final ReadableByteChannel readableByteChannel;
 
     private FileInputStream fis;

--- a/isoparser/src/main/java/org/mp4parser/IsoFile.java
+++ b/isoparser/src/main/java/org/mp4parser/IsoFile.java
@@ -19,12 +19,10 @@ package org.mp4parser;
 import org.mp4parser.boxes.iso14496.part12.MovieBox;
 import org.mp4parser.support.DoNotParseDetail;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.*;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
 
 /**
  * The most upper container for ISO Boxes. It is a container box that is a file.
@@ -32,16 +30,19 @@ import java.nio.channels.WritableByteChannel;
  */
 @DoNotParseDetail
 public class IsoFile extends BasicContainer implements Closeable {
-    private static Logger LOG = LoggerFactory.getLogger(IsoFile.class);
-    private ReadableByteChannel readableByteChannel;
+    private final ReadableByteChannel readableByteChannel;
+
+    private FileInputStream fis;
 
 
     public IsoFile(String file) throws IOException {
-        this(new FileInputStream(file).getChannel(), new PropertyBoxParserImpl());
+        this(new File(file));
     }
 
     public IsoFile(File file) throws IOException {
-        this(new FileInputStream(file).getChannel(), new PropertyBoxParserImpl());
+        this.fis = new FileInputStream(file);
+        this.readableByteChannel = fis.getChannel();
+        initContainer(readableByteChannel, -1, new PropertyBoxParserImpl());
     }
 
     /**
@@ -72,11 +73,7 @@ public class IsoFile extends BasicContainer implements Closeable {
         if (type != null) {
             System.arraycopy(type, 0, result, 0, Math.min(type.length, 4));
         }
-        try {
-            return new String(result, "ISO-8859-1");
-        } catch (UnsupportedEncodingException e) {
-            throw new Error("Required character encoding is missing", e);
-        }
+        return new String(result, StandardCharsets.ISO_8859_1);
     }
 
 
@@ -104,12 +101,17 @@ public class IsoFile extends BasicContainer implements Closeable {
         writeContainer(os);
     }
 
+    @Override
     public void close() throws IOException {
         this.readableByteChannel.close();
+        if (this.fis != null) {
+            this.fis.close();
+        }
+        super.close();
     }
 
     @Override
     public String toString() {
-        return "model(" + readableByteChannel.toString() + ")";
+        return "model(" + readableByteChannel + ")";
     }
 }

--- a/isoparser/src/main/java/org/mp4parser/IsoFile.java
+++ b/isoparser/src/main/java/org/mp4parser/IsoFile.java
@@ -29,7 +29,7 @@ import java.nio.charset.StandardCharsets;
  * Uses IsoBufferWrapper  to access the underlying file.
  */
 @DoNotParseDetail
-public class IsoFile extends BasicContainer {
+public class IsoFile extends BasicContainer implements Closeable {
     private final ReadableByteChannel readableByteChannel;
 
     private FileInputStream fis;
@@ -107,7 +107,11 @@ public class IsoFile extends BasicContainer {
         if (this.fis != null) {
             this.fis.close();
         }
-        super.close();
+        for (Box box : getBoxes()) {
+            if (box instanceof Closeable) {
+                ((Closeable) box).close();
+            }
+        }
     }
 
     @Override

--- a/isoparser/src/main/java/org/mp4parser/boxes/apple/TimeCodeBox.java
+++ b/isoparser/src/main/java/org/mp4parser/boxes/apple/TimeCodeBox.java
@@ -168,7 +168,7 @@ public class TimeCodeBox extends AbstractBox implements SampleEntry, Container {
     }
 
     public void setBoxes(List<? extends Box> boxes) {
-        throw new RuntimeException("Time Code Box doesn't accept any children");
+        throw new UnsupportedOperationException("Time Code Box doesn't accept any children");
     }
 
     public <T extends Box> List<T> getBoxes(Class<T> clazz) {
@@ -180,5 +180,10 @@ public class TimeCodeBox extends AbstractBox implements SampleEntry, Container {
     }
 
     public void writeContainer(WritableByteChannel bb) throws IOException {
+    }
+
+    @Override
+    public void close() throws IOException {
+        // no-op
     }
 }

--- a/isoparser/src/main/java/org/mp4parser/boxes/apple/TimeCodeBox.java
+++ b/isoparser/src/main/java/org/mp4parser/boxes/apple/TimeCodeBox.java
@@ -181,9 +181,4 @@ public class TimeCodeBox extends AbstractBox implements SampleEntry, Container {
 
     public void writeContainer(WritableByteChannel bb) throws IOException {
     }
-
-    @Override
-    public void close() throws IOException {
-        // no-op
-    }
 }


### PR DESCRIPTION
Extend Closeable in Container and modify BasicContainer to close all
child boxes when it is closed, giving all child boxes a chance to
release any resources that they hold.

Prevent new IsoFile(String) and new IsoFile(File) from leaking file
descriptors by implementing Closeable and ensuring that FileInputStream
reference is stored and closed when IsoFile is closed.

Prevent MediaDataBox from exhausting space in /tmp by removing
disk-buffered data file when IsoFile is closed.

Convert some stream definitions to use Java 7 try-with-resources syntax

Remove superfluous explicit toString invocations for string concatenation