### PR TITLE
Cast ByteBuffer to Buffer

### DIFF
--- a/isoparser/src/main/java/org/mp4parser/AbstractBoxParser.java
+++ b/isoparser/src/main/java/org/mp4parser/AbstractBoxParser.java
@@ -81,9 +81,9 @@ public abstract class AbstractBoxParser implements BoxParser {
         long contentSize;
 
         if (size == 1) {
-            header.get().limit(16);
+            ((Buffer)header.get()).limit(16);
             byteChannel.read(header.get());
-            header.get().position(8);
+            ((Buffer)header.get()).position(8);
             size = IsoTypeReader.readUInt64(header.get());
             contentSize = size - 16;
         } else if (size == 0) {
@@ -92,11 +92,11 @@ public abstract class AbstractBoxParser implements BoxParser {
             contentSize = size - 8;
         }
         if (UserBox.TYPE.equals(type)) {
-            header.get().limit(header.get().limit() + 16);
+            ((Buffer)header.get()).limit(((Buffer)header.get()).limit() + 16);
             byteChannel.read(header.get());
             usertype = new byte[16];
-            for (int i = header.get().position() - 16; i < header.get().position(); i++) {
-                usertype[i - (header.get().position() - 16)] = header.get().get(i);
+            for (int i = ((Buffer)header.get()).position() - 16; i < ((Buffer)header.get()).position(); i++) {
+                usertype[i - (((Buffer)header.get()).position() - 16)] = header.get().get(i);
             }
             contentSize -= 16;
         }


### PR DESCRIPTION
Thank you for your great library. It works great on Android 10 but we found the problem on Android 8 and 9. I got the following error.

```
Fatal Exception: java.lang.NoSuchMethodError: No virtual method limit(I)Ljava/nio/ByteBuffer; in class Ljava/nio/ByteBuffer; or its super classes (declaration of 'java.nio.ByteBuffer' appears in /system/framework/core-oj.jar)
       at org.mp4parser.AbstractBoxParser.parseBox(AbstractBoxParser.java:84)
       at org.mp4parser.BasicContainer.initContainer(BasicContainer.java:107)
       at org.mp4parser.IsoFile.<init>(IsoFile.java:57)
       at org.mp4parser.IsoFile.<init>(IsoFile.java:52)
       at org.mp4parser.muxer.container.mp4.MovieCreator.build(MovieCreator.java:54)
       at org.mp4parser.muxer.container.mp4.MovieCreator.build(MovieCreator.java:39)
```


This seems to be the same problem that fixed in this commit. https://github.com/sannies/mp4parser/commit/0fdd054d7cd65b0328ec685e0e8ac20a16216fe6
I added codes that cast ByteBuffer to Buffer then the problem solved at least on my devices (SC-02H).

