### PR TITLE
Move junit to the test scope

### DIFF
--- a/muxer/pom.xml
+++ b/muxer/pom.xml
@@ -22,6 +22,7 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
closes #433 

This PR moves the junit dependency from the production scope to the test scope to avoid leaking it when deploying the artifact.