### PR TITLE
fix:"ClassLoader.getSystemResourceAsStream" NullPointException

### DIFF
--- a/isoparser/src/main/java/org/mp4parser/PropertyBoxParserImpl.java
+++ b/isoparser/src/main/java/org/mp4parser/PropertyBoxParserImpl.java
@@ -49,11 +49,15 @@ public class PropertyBoxParserImpl extends AbstractBoxParser {
             try {
                 mapping = new Properties();
                 try {
-                    mapping.load(is);
                     ClassLoader cl = Thread.currentThread().getContextClassLoader();
                     if (cl == null) {
                         cl = ClassLoader.getSystemClassLoader();
                     }
+                    if (null == is) {
+                        is = cl.getResourceAsStream("isoparser2-default.properties");
+                    }
+                    mapping.load(is);
+
                     Enumeration<URL> enumeration = cl.getResources("isoparser-custom.properties");
 
                     while (enumeration.hasMoreElements()) {

--- a/isoparser/src/main/java/org/mp4parser/PropertyBoxParserImpl.java
+++ b/isoparser/src/main/java/org/mp4parser/PropertyBoxParserImpl.java
@@ -53,7 +53,7 @@ public class PropertyBoxParserImpl extends AbstractBoxParser {
                     if (cl == null) {
                         cl = ClassLoader.getSystemClassLoader();
                     }
-                    if (null == is) {
+                    if (is == null) {
                         is = cl.getResourceAsStream("isoparser2-default.properties");
                     }
                     mapping.load(is);


### PR DESCRIPTION
Fix: #449 


Problem: jdk17, "org.mp4parser.muxer.container.mp4.MovieCreator.build(path)" throw NPE
```java
java.lang.NullPointerException: inStream parameter is null
        at java.base/java.util.Objects.requireNonNull(Objects.java:233)
        at java.base/java.util.Properties.load(Properties.java:407)
        at org.mp4parser.PropertyBoxParserImpl.<init>(PropertyBoxParserImpl.java:52)
        at org.mp4parser.IsoFile.<init>(IsoFile.java:53)
        at org.mp4parser.muxer.container.mp4.MovieCreator.build(MovieCreator.java:54)
```

And I find in "org/mp4parser/PropertyBoxParserImpl.java:48  " return null
```java
InputStream is = ClassLoader.getSystemResourceAsStream("isoparser2-default.properties"); //return null 
```



