### PR TITLE
fix:"ClassLoader.getSystemResourceAsStream" NullPointException

### DIFF
--- a/isoparser/src/main/java/org/mp4parser/PropertyBoxParserImpl.java
+++ b/isoparser/src/main/java/org/mp4parser/PropertyBoxParserImpl.java
@@ -45,16 +45,15 @@ public class PropertyBoxParserImpl extends AbstractBoxParser {
         if (BOX_MAP_CACHE != null) {
             mapping = new Properties(BOX_MAP_CACHE);
         } else {
-            ClassLoader cs = Thread.currentThread().getContextClassLoader();
-            InputStream is = classLoader.getResourceAsStream("isoparser2-default.properties");
+            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            if (cl == null) {
+                cl = ClassLoader.getSystemClassLoader();
+            }
+            InputStream is = cl.getResourceAsStream("isoparser2-default.properties");
             try {
                 mapping = new Properties();
                 try {
                     mapping.load(is);
-                    ClassLoader cl = Thread.currentThread().getContextClassLoader();
-                    if (cl == null) {
-                        cl = ClassLoader.getSystemClassLoader();
-                    }
                     Enumeration<URL> enumeration = cl.getResources("isoparser-custom.properties");
 
                     while (enumeration.hasMoreElements()) {

--- a/isoparser/src/main/java/org/mp4parser/PropertyBoxParserImpl.java
+++ b/isoparser/src/main/java/org/mp4parser/PropertyBoxParserImpl.java
@@ -45,7 +45,8 @@ public class PropertyBoxParserImpl extends AbstractBoxParser {
         if (BOX_MAP_CACHE != null) {
             mapping = new Properties(BOX_MAP_CACHE);
         } else {
-            InputStream is = ClassLoader.getSystemResourceAsStream("isoparser2-default.properties");
+            ClassLoader cs = Thread.currentThread().getContextClassLoader();
+            InputStream is = classLoader.getResourceAsStream("isoparser2-default.properties");
             try {
                 mapping = new Properties();
                 try {


### PR DESCRIPTION
Fix: https://github.com/sannies/mp4parser/issues/449

Problem
`org.mp4parser.muxer.container.mp4.MovieCreator.build(path)` throws NPE
Root cause
`InputStream is = ClassLoader.getSystemResourceAsStream("isoparser2-default.properties");`
returns null.
Fixed by replacing with
```
ClassLoader cs = Thread.currentThread().getContextClassLoader();
InputStream is = classLoader.getResourceAsStream("isoparser2-default.properties");
```
